### PR TITLE
fix(security): replace regex sanitizer with escaped formatter

### DIFF
--- a/astrologo-frontend/functions/api/analisar.ts
+++ b/astrologo-frontend/functions/api/analisar.ts
@@ -66,21 +66,31 @@ const countTokensEndpoint = (apiKey: string) =>
 const generateContentEndpoint = (apiKey: string) =>
   `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_CONFIG.model}:generateContent?key=${apiKey}`;
 
-const sanitizeGeneratedHtml = (input: string): string => {
-  const withoutFences = input.replace(/```html/gi, '').replace(/```/g, '');
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 
-  return withoutFences
-    .replace(/<\s*(script|style|iframe|object|embed|link|meta|base|form|input|button|textarea|select|svg|math)[^>]*>[\s\S]*?<\s*\/\s*\1>/gi, '')
-    .replace(/<\s*(script|style|iframe|object|embed|link|meta|base|form|input|button|textarea|select|svg|math)[^>]*\/?>/gi, '')
-    .replace(/\son\w+\s*=\s*(['"]).*?\1/gi, '')
-    .replace(/\sstyle\s*=\s*(['"]).*?\1/gi, '')
-    .replace(/\s(href|src)\s*=\s*(['"])\s*(javascript|data|vbscript)\s*:[\s\S]*?\2/gi, '')
-    .replace(/javascript:/gi, '')
-    .replace(/data:/gi, '')
-    .replace(/vbscript:/gi, '')
-    .replace(/<(?!\/?(p|strong|ul|li|em|b|i|h1|h2|h3|br)\b)[^>]*>/gi, '')
-    .replace(/<(p|strong|ul|li|em|b|i|h1|h2|h3|br)\s[^>]*>/gi, '<$1>')
+const sanitizeGeneratedHtml = (input: string): string => {
+  const normalized = input
+    .replace(/```html/gi, '')
+    .replace(/```/g, '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
     .trim();
+
+  if (!normalized) {
+    return '<p>Perturbação no éter na geração.</p>';
+  }
+
+  const escaped = escapeHtml(normalized);
+  return escaped
+    .split(/\n{2,}/)
+    .map((block) => `<p>${block.replace(/\n/g, '<br>')}</p>`)
+    .join('');
 };
 
 /**

--- a/astrologo-frontend/src/App.tsx
+++ b/astrologo-frontend/src/App.tsx
@@ -25,6 +25,15 @@ const sanitizeRichHtml = (html: string): string => DOMPurify.sanitize(html, {
   ALLOWED_ATTR: []
 });
 
+const htmlToPlainText = (html: string): string => {
+  if (typeof DOMParser === 'undefined') {
+    return html;
+  }
+
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  return (doc.body.textContent ?? '').replace(/\u00a0/g, ' ');
+};
+
 interface AstroData { astro: string; signo: string; simbolo: string; }
 interface UmbandaData { posicao: string; orixa: string; simbolo: string; }
 interface DadosGlobais { tatwa: { principal: string; sub: string; }; numerologia: { expressao: number; caminhoVida: number; vibracaoHora: number; }; }
@@ -231,7 +240,7 @@ export const ResultView: React.FC<ResultViewProps> = ({ result, analiseIa, onSol
     t += blocoTexto(result.dadosAstronomica);
 
     if (analiseIa) {
-      const iaTxt = analiseIa.replace(/<br\s*\/?>/gi, '\n').replace(/<\/p>/gi, '\n\n').replace(/<strong>(.*?)<\/strong>/gi, '*$1*').replace(/<b>(.*?)<\/b>/gi, '*$1*').replace(/<em>(.*?)<\/em>/gi, '_$1_').replace(/<i>(.*?)<\/i>/gi, '_$1_').replace(/<li>(.*?)<\/li>/gi, '• $1\n').replace(/<\/ul>/gi, '\n').replace(/<h[1-6][^>]*>(.*?)<\/h[1-6]>/gi, '\n*$1*\n').replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&');
+      const iaTxt = htmlToPlainText(analiseIa);
       t += divider;
       t += `*🧠 SÍNTESE DO MESTRE (IA)*\n\n` + iaTxt.replace(/\n{3,}/g, '\n\n').trim() + `\n`;
     }


### PR DESCRIPTION
## Summary\n- Replace regex-heavy sanitizer with escape-and-format strategy\n- Emit safe HTML paragraphs only (p/br)\n\n## Why\nReduce CodeQL incomplete sanitization findings while preserving readable output.