### PR TITLE
chore: update sponsors page to SumUp

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -4,238 +4,175 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <meta name="color-scheme" content="light dark" />
-<title>Apoie Meus Projetos · PIX</title>
-<meta name="description" content="Página de doação PIX para projetos open-source de Leonardo Cardozo Vargas." />
+<title>Apoie a LCV Ideas &amp; Software · SumUp</title>
+<meta name="description" content="Página de apoio aos projetos open-source da LCV Ideas &amp; Software com integração SumUp Card Widget." />
 <meta name="robots" content="noindex,follow" />
 <style>
   :root {
-    --bg: #ffffff;
-    --fg: #0f172a;
-    --muted: #475569;
-    --card: #f8fafc;
-    --border: #e2e8f0;
+    --bg: #f7f9fc;
+    --fg: #101827;
+    --muted: #526071;
+    --card: #ffffff;
+    --border: #d8e0ea;
     --accent: #2563eb;
-    --code-bg: #f1f5f9;
-    --code-fg: #0f172a;
-    --ok: #16a34a;
+    --accent-strong: #0f766e;
+    --soft: #eef7f6;
   }
   @media (prefers-color-scheme: dark) {
     :root {
       --bg: #0b1220;
-      --fg: #e2e8f0;
-      --muted: #94a3b8;
+      --fg: #e7edf5;
+      --muted: #9aa8ba;
       --card: #111827;
-      --border: #1f2937;
+      --border: #253246;
       --accent: #60a5fa;
-      --code-bg: #0f172a;
-      --code-fg: #e2e8f0;
-      --ok: #22c55e;
+      --accent-strong: #2dd4bf;
+      --soft: #0f2428;
     }
   }
   * { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; }
   body {
-    font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    min-height: 100vh;
     background: var(--bg);
     color: var(--fg);
-    min-height: 100vh;
+    font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 24px 16px;
+    padding: 28px 16px;
   }
   main {
-    max-width: 560px;
-    width: 100%;
+    width: min(720px, 100%);
+  }
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 22px;
+  }
+  .mark {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+    color: white;
+    font-weight: 800;
+    letter-spacing: 0;
   }
   h1 {
-    font-size: 24px;
-    margin: 0 0 4px;
-    font-weight: 700;
-    letter-spacing: -0.01em;
+    font-size: 28px;
+    line-height: 1.15;
+    margin: 0;
+    font-weight: 750;
+    letter-spacing: 0;
   }
   .lede {
     color: var(--muted);
-    margin: 0 0 24px;
-    font-size: 14px;
+    margin: 8px 0 0;
+    font-size: 15px;
   }
-  .lede a { color: var(--accent); text-decoration: none; }
-  .lede a:hover { text-decoration: underline; }
-  .card {
+  .panel {
     background: var(--card);
     border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: 20px;
-    margin-bottom: 16px;
-  }
-  .qr-wrap {
-    background: #ffffff;
-    border-radius: 8px;
-    padding: 16px;
-    display: flex;
-    justify-content: center;
-    margin-bottom: 12px;
-  }
-  .qr-wrap svg {
-    width: 240px;
-    height: 240px;
-    display: block;
-    image-rendering: pixelated;
-  }
-  .qr-caption {
-    text-align: center;
-    color: var(--muted);
-    font-size: 13px;
-    margin: 0;
+    border-radius: 14px;
+    padding: 24px;
+    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
   }
   h2 {
-    font-size: 14px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--muted);
+    font-size: 16px;
     margin: 0 0 8px;
-    font-weight: 600;
+    font-weight: 700;
+    letter-spacing: 0;
   }
-  code, .code-block {
-    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-  }
-  .code-block {
-    background: var(--code-bg);
-    color: var(--code-fg);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 12px;
-    font-size: 13px;
-    word-break: break-all;
-    overflow-wrap: anywhere;
-    margin: 0 0 8px;
-  }
-  .copy-row {
-    display: flex;
-    gap: 8px;
-    align-items: stretch;
-    margin-bottom: 4px;
-  }
-  .copy-row .code-block { flex: 1; margin: 0; }
-  button {
+  p { margin: 0; }
+  .muted { color: var(--muted); }
+  .cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 46px;
+    margin-top: 18px;
+    padding: 0 18px;
+    border-radius: 10px;
     background: var(--accent);
     color: white;
-    border: 0;
-    border-radius: 8px;
-    padding: 0 16px;
-    font-size: 14px;
-    font-weight: 600;
-    cursor: pointer;
-    white-space: nowrap;
-    font-family: inherit;
+    text-decoration: none;
+    font-weight: 700;
   }
-  button:hover { filter: brightness(1.05); }
-  button:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
-  button.copied { background: var(--ok); }
-  ol {
-    margin: 0;
-    padding-left: 20px;
+  .cta:hover { filter: brightness(1.05); }
+  .note {
+    margin-top: 18px;
+    padding: 14px 16px;
+    border-radius: 10px;
+    background: var(--soft);
     color: var(--muted);
+    border: 1px solid var(--border);
     font-size: 14px;
   }
-  ol li { margin-bottom: 4px; }
-  ol li strong { color: var(--fg); font-weight: 600; }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+    margin-top: 18px;
+  }
+  .mini {
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 14px;
+    background: transparent;
+  }
+  .mini strong { display: block; margin-bottom: 4px; }
+  a { color: var(--accent); }
   footer {
-    text-align: center;
     color: var(--muted);
     font-size: 13px;
-    margin-top: 24px;
+    margin-top: 18px;
+    text-align: center;
   }
-  footer a { color: var(--accent); text-decoration: none; }
-  footer a:hover { text-decoration: underline; }
+  @media (max-width: 620px) {
+    h1 { font-size: 24px; }
+    .grid { grid-template-columns: 1fr; }
+    .panel { padding: 20px; }
+  }
 </style>
 </head>
 <body>
 <main>
-  <h1>Apoie <code>Meus Projetos</code></h1>
-  <p class="lede">Doação via PIX para projetos open-source de <a href="https://github.com/lcv-leo">Leonardo Cardozo Vargas</a>. Lista completa em <a href="https://github.com/lcv-leo?tab=repositories">github.com/lcv-leo</a>.</p>
-
-  <section class="card" aria-labelledby="qr-h">
-    <h2 id="qr-h">QR Code</h2>
-    <div class="qr-wrap" aria-hidden="false">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 53 53" shape-rendering="crispEdges"><path fill="#ffffff" d="M0 0h53v53H0z"/><path stroke="#000000" d="M4 4.5h7m5 0h2m1 0h4m3 0h2m1 0h2m3 0h2m1 0h1m2 0h1m1 0h7M4 5.5h1m5 0h1m5 0h1m8 0h1m1 0h1m1 0h1m1 0h3m3 0h1m1 0h1m2 0h1m5 0h1M4 6.5h1m1 0h3m1 0h1m1 0h4m1 0h1m2 0h1m1 0h3m1 0h1m1 0h1m2 0h1m3 0h1m1 0h1m1 0h1m2 0h1m1 0h3m1 0h1M4 7.5h1m1 0h3m1 0h1m1 0h2m1 0h1m1 0h2m1 0h6m2 0h2m2 0h1m6 0h2m1 0h1m1 0h3m1 0h1M4 8.5h1m1 0h3m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h3m1 0h5m2 0h3m3 0h4m1 0h1m1 0h3m1 0h1M4 9.5h1m5 0h1m1 0h5m2 0h3m2 0h1m3 0h2m1 0h1m2 0h1m2 0h1m4 0h1m5 0h1M4 10.5h7m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h7M12 11.5h2m2 0h1m7 0h1m3 0h2m1 0h1m1 0h1m1 0h1M4 12.5h1m1 0h5m5 0h2m2 0h2m2 0h5m1 0h1m2 0h2m1 0h1m5 0h5M4 13.5h2m1 0h1m1 0h1m3 0h1m1 0h2m2 0h2m1 0h1m1 0h2m1 0h2m1 0h2m1 0h1m1 0h2m2 0h1m3 0h1m2 0h1M4 14.5h1m2 0h4m1 0h1m3 0h2m5 0h1m1 0h1m2 0h1m1 0h1m2 0h3m2 0h1m1 0h1m2 0h2M5 15.5h1m5 0h2m4 0h1m1 0h1m2 0h1m2 0h4m1 0h2m2 0h2m1 0h2m1 0h1m1 0h2m1 0h2M6 16.5h2m2 0h2m1 0h1m1 0h1m3 0h5m1 0h1m2 0h1m1 0h1m1 0h4m1 0h4m2 0h1M5 17.5h2m6 0h2m1 0h1m1 0h2m1 0h2m3 0h1m1 0h2m1 0h2m1 0h1m3 0h4m2 0h1M5 18.5h1m1 0h1m2 0h1m1 0h1m1 0h5m3 0h2m1 0h2m1 0h1m1 0h1m1 0h1m2 0h1m1 0h1m2 0h1m1 0h1m1 0h3m1 0h1M7 19.5h2m5 0h1m1 0h1m3 0h1m1 0h1m1 0h1m1 0h1m1 0h3m2 0h1m1 0h1m1 0h2m1 0h1m4 0h3M6 20.5h1m1 0h1m1 0h2m4 0h1m1 0h1m2 0h1m1 0h1m1 0h1m3 0h1m1 0h3m1 0h1m1 0h2m1 0h2m1 0h1m1 0h1M4 21.5h2m1 0h3m1 0h1m5 0h3m2 0h2m2 0h1m2 0h1m2 0h6m2 0h1m2 0h2m1 0h1m1 0h1M4 22.5h3m3 0h3m5 0h1m2 0h3m3 0h3m1 0h1m1 0h1m2 0h2m1 0h2m2 0h1m1 0h1m2 0h1M4 23.5h4m3 0h1m2 0h2m1 0h1m2 0h1m1 0h1m1 0h2m2 0h7m1 0h1m4 0h1m1 0h2m1 0h1M4 24.5h1m1 0h1m1 0h5m1 0h3m2 0h1m1 0h1m2 0h5m1 0h1m3 0h1m4 0h6M4 25.5h5m3 0h1m2 0h3m1 0h1m1 0h2m1 0h1m3 0h6m2 0h1m2 0h2m3 0h1m1 0h1M4 26.5h3m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m2 0h2m1 0h1m1 0h1m1 0h1m1 0h1m3 0h1m1 0h1m3 0h1m1 0h1m1 0h1m1 0h2m1 0h2M5 27.5h1m2 0h1m3 0h2m1 0h1m1 0h2m2 0h2m1 0h1m3 0h1m2 0h1m1 0h2m1 0h1m3 0h1m3 0h1m1 0h1M6 28.5h1m1 0h6m1 0h2m1 0h1m1 0h1m1 0h1m1 0h5m2 0h1m2 0h1m3 0h1m1 0h5m2 0h2M6 29.5h1m1 0h1m2 0h1m1 0h2m2 0h1m1 0h1m1 0h3m1 0h2m1 0h1m2 0h1m1 0h1m2 0h2m1 0h1m1 0h1M7 30.5h2m1 0h1m4 0h1m2 0h3m2 0h1m4 0h1m2 0h1m2 0h5m3 0h3m3 0h1M8 31.5h1m2 0h1m3 0h2m3 0h3m1 0h2m3 0h1m1 0h1m1 0h2m1 0h1m5 0h7M4 32.5h1m3 0h3m2 0h1m4 0h4m1 0h1m2 0h1m1 0h1m2 0h1m1 0h3m1 0h1m2 0h2m1 0h1M5 33.5h1m8 0h1m2 0h4m3 0h2m3 0h3m4 0h1m3 0h3m1 0h2m2 0h1M4 34.5h2m3 0h5m2 0h1m1 0h1m1 0h1m1 0h2m2 0h1m1 0h1m2 0h1m1 0h4m1 0h1m1 0h1m4 0h1m1 0h1M4 35.5h1m3 0h1m2 0h3m9 0h3m1 0h1m2 0h1m1 0h1m2 0h1m3 0h1m1 0h1m1 0h2m2 0h2M4 36.5h4m2 0h1m1 0h2m1 0h2m1 0h2m1 0h1m1 0h1m2 0h1m2 0h3m1 0h1m1 0h4m1 0h1m1 0h1m2 0h1M4 37.5h1m1 0h2m1 0h1m1 0h1m1 0h1m1 0h1m2 0h1m1 0h3m3 0h2m1 0h1m1 0h1m1 0h7m3 0h1m1 0h1M8 38.5h1m1 0h2m1 0h1m1 0h1m1 0h3m3 0h1m1 0h1m2 0h2m1 0h2m2 0h3m2 0h7M5 39.5h4m2 0h3m3 0h2m1 0h2m1 0h2m2 0h1m3 0h4m1 0h1m9 0h1M4 40.5h1m2 0h2m1 0h3m1 0h1m4 0h1m4 0h6m8 0h1m1 0h7m1 0h1M12 41.5h1m2 0h5m4 0h1m3 0h1m2 0h3m2 0h2m2 0h1m3 0h3M4 42.5h7m4 0h1m2 0h1m1 0h1m1 0h3m1 0h1m1 0h2m1 0h1m2 0h1m2 0h1m2 0h1m1 0h1m1 0h5M4 43.5h1m5 0h1m1 0h2m1 0h1m2 0h2m1 0h2m1 0h1m3 0h1m1 0h3m1 0h5m1 0h1m3 0h1m1 0h1m1 0h1M4 44.5h1m1 0h3m1 0h1m1 0h1m3 0h1m2 0h1m1 0h1m2 0h7m2 0h1m1 0h3m2 0h5m1 0h1m1 0h1M4 45.5h1m1 0h3m1 0h1m1 0h3m2 0h1m2 0h1m1 0h1m2 0h1m1 0h1m8 0h4m1 0h4m1 0h1M4 46.5h1m1 0h3m1 0h1m1 0h1m1 0h3m3 0h2m2 0h1m3 0h2m1 0h13M4 47.5h1m5 0h1m6 0h1m4 0h1m7 0h3m1 0h1m1 0h2m7 0h3M4 48.5h7m1 0h1m2 0h2m1 0h1m1 0h1m2 0h6m2 0h5m1 0h2m1 0h2m3 0h2"/></svg>
+  <header class="brand">
+    <div class="mark" aria-hidden="true">LCV</div>
+    <div>
+      <h1>Apoie a LCV Ideas &amp; Software</h1>
+      <p class="lede">Projetos open-source, apps web, automações e ferramentas editoriais mantidos pela organização.</p>
     </div>
-    <p class="qr-caption">Escaneie no app do banco · qualquer valor aceito</p>
-  </section>
+  </header>
 
-  <section class="card" aria-labelledby="copia-h">
-    <h2 id="copia-h">PIX Copia e Cola</h2>
-    <div class="copy-row">
-      <div class="code-block" id="payload">00020126580014BR.GOV.BCB.PIX0136c9328705-fa51-44c0-b972-bca71e2d06bd5204000053039865802BR5917LEONARDO C VARGAS6014RIO DE JANEIRO62070503***6304D26C</div>
-      <button type="button" id="copy-btn" aria-label="Copiar PIX Copia e Cola">Copiar</button>
+  <section class="panel" aria-labelledby="payment-title">
+    <h2 id="payment-title">Pagamento seguro via SumUp</h2>
+    <p class="muted">O fluxo de apoio passa a usar a integração oficial SumUp Card Widget, sem publicar chaves de pagamento ou dados sensíveis no repositório.</p>
+    <a class="cta" href="https://developer.sumup.com/online-payments/checkouts/card-widget" target="_blank" rel="noopener noreferrer">Abrir SumUp Card Widget</a>
+
+    <div class="note">
+      Esta página substitui o antigo fluxo de pagamento estático. Nenhum dado de cartão é coletado por este site; a operação deve ser conduzida pelo ambiente seguro da SumUp.
     </div>
-  </section>
 
-  <section class="card" aria-labelledby="key-h">
-    <h2 id="key-h">Chave PIX (aleatória)</h2>
-    <div class="copy-row">
-      <div class="code-block" id="pixkey">c9328705-fa51-44c0-b972-bca71e2d06bd</div>
-      <button type="button" id="copy-key" aria-label="Copiar chave PIX">Copiar</button>
+    <div class="grid" aria-label="Links do projeto">
+      <div class="mini">
+        <strong>Organização</strong>
+        <a href="https://github.com/LCV-Ideas-Software" target="_blank" rel="noopener noreferrer">LCV Ideas &amp; Software</a>
+      </div>
+      <div class="mini">
+        <strong>Repositório</strong>
+        <a href="https://github.com/LCV-Ideas-Software/astrologo-app" target="_blank" rel="noopener noreferrer">astrologo-app</a>
+      </div>
     </div>
-  </section>
-
-  <section class="card" aria-labelledby="how-h">
-    <h2 id="how-h">Como pagar</h2>
-    <ol>
-      <li><strong>Abra o app do seu banco</strong> e vá em PIX.</li>
-      <li><strong>QR Code:</strong> escaneie a imagem acima · <strong>ou Copia e Cola:</strong> cole o código gerado · <strong>ou Chave:</strong> use a chave aleatória.</li>
-      <li>O recebedor aparecerá como <strong>LEONARDO CARDOZO VARGAS</strong>.</li>
-      <li>Defina o valor que quiser e confirme.</li>
-    </ol>
   </section>
 
   <footer>
-    <p>Recebedor: <strong>LEONARDO C VARGAS</strong> · Cidade: <strong>RIO DE JANEIRO</strong></p>
-    <p><a href="https://github.com/lcv-leo">Perfil GitHub</a> · <a href="https://github.com/sponsors/lcv-leo">GitHub Sponsors</a></p>
+    <p>Página de apoio do projeto Astrologo App.</p>
   </footer>
 </main>
-
-<script>
-(function () {
-  function setupCopy(btnId, srcId) {
-    var btn = document.getElementById(btnId);
-    var src = document.getElementById(srcId);
-    if (!btn || !src) return;
-    btn.addEventListener('click', function () {
-      var text = src.textContent.trim();
-      function done() {
-        var prev = btn.textContent;
-        btn.textContent = 'Copiado';
-        btn.classList.add('copied');
-        setTimeout(function () {
-          btn.textContent = prev;
-          btn.classList.remove('copied');
-        }, 1500);
-      }
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(text).then(done, fallback);
-      } else {
-        fallback();
-      }
-      function fallback() {
-        var ta = document.createElement('textarea');
-        ta.value = text;
-        ta.style.position = 'fixed';
-        ta.style.left = '-9999px';
-        document.body.appendChild(ta);
-        ta.focus();
-        ta.select();
-        try { document.execCommand('copy'); done(); } catch (e) {}
-        document.body.removeChild(ta);
-      }
-    });
-  }
-  setupCopy('copy-btn', 'payload');
-  setupCopy('copy-key', 'pixkey');
-})();
-</script>
 </body>
 </html>


### PR DESCRIPTION
Atualiza a página customizada de Sponsors para remover o fluxo PIX estático e apontar para a integração oficial SumUp Card Widget.

Validação local:
- g não encontra lcv-leo, PIX, payload/chave antiga ou nome do recebedor em site/index.html.
- O link https://developer.sumup.com/online-payments/checkouts/card-widget respondeu HTTP 200.