### PR TITLE
[codex] Harden workflow security alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,13 +41,13 @@ jobs:
         with:
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
           dependency-caching: true
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,13 +9,16 @@ on:
     - cron: "17 6 * * 2"
 permissions:
   contents: read
-  security-events: write
   actions: read
 concurrency:
   group: codeql-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   analyze:
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     name: Analyze ${{ matrix.language }}
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,6 @@ jobs:
           path: scorecard-results.sarif
           retention-days: 5
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: scorecard-results.sarif


### PR DESCRIPTION
## Summary
- Scope CodeQL `security-events: write` to the analyze job instead of the workflow top level.
- Update pinned `github/codeql-action` references from `v4.35.4` to `v4.35.5`.

## Validation
- Parsed all active workflow YAML files locally.
- `git diff --check` passed.
- Verified GitHub Actions versions before opening this PR; no other pinned actions in this repo required updates.