### PR TITLE
fix: unblock undici security update

### DIFF
--- a/astrologo-frontend/package-lock.json
+++ b/astrologo-frontend/package-lock.json
@@ -4003,9 +4003,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/astrologo-frontend/package.json
+++ b/astrologo-frontend/package.json
@@ -59,7 +59,7 @@
   },
   "overrides": {
     "picomatch": "4.0.4",
-    "undici": "6.24.0",
+    "undici": "6.27.0",
     "vite": "$vite",
     "protobufjs": "7.6.3",
     "@babel/core": "7.29.6"


### PR DESCRIPTION
## What changed

- updates the frontend `undici` override from `6.24.0` to `6.27.0`;
- regenerates the matching lockfile entry, including its resolved URL and integrity hash.

## Root cause

`@fusionstrings/swiss-eph@0.1.1` accepts `undici ^6.0.0`, but the application's older global override forced `6.24.0`. Dependabot Updates run #260 requires the first patched 6.x release, `6.27.0`, and therefore could not construct the security update.

## Impact

The dependency remains dev-only and on the same major line. The change clears the known `undici` advisories while preserving the repository's deterministic override policy.

## Validation

- clean `npm ci --no-audit --no-fund`;
- `npm ls`: `@fusionstrings/swiss-eph@0.1.1 -> undici@6.27.0`;
- `npm audit`: zero vulnerabilities;
- Vitest: 74/74;
- ESLint;
- Biome;
- production build;
- `git diff --check`.
