### PR TITLE
fix: preserve exact release validation evidence

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -108,8 +108,14 @@ jobs:
           assert_target_version() {
             local target_sha="$1"
             local source raw target_version
-            if ! source="$(git show "${target_sha}:${VERSION_FILE}" 2>/dev/null)"; then
-              echo "::error::${VERSION_FILE} is missing at reconciliation target ${target_sha}." >&2
+            if ! source="$(
+              gh api --method GET \
+                -H "Accept: application/vnd.github.raw+json" \
+                -H "X-GitHub-Api-Version: 2026-03-10" \
+                "repos/${GITHUB_REPOSITORY}/contents/${VERSION_FILE}" \
+                -f ref="$target_sha"
+            )"; then
+              echo "::error::Could not fetch ${VERSION_FILE} from remote reconciliation target ${target_sha}." >&2
               return 1
             fi
             raw="$(grep -E "APP_VERSION[[:space:]]*=[[:space:]]*['\"]APP v[0-9]+\.[0-9]+\.[0-9]+['\"]" <<<"$source" | head -1 || true)"
@@ -447,6 +453,7 @@ jobs:
         run: |
           set -euo pipefail
           readonly poll_seconds=10
+          readonly expected_categories='["/language:actions","/language:javascript-typescript"]'
           deadline=$((SECONDS + 300))
 
           while true; do
@@ -481,6 +488,22 @@ jobs:
               continue
             fi
 
+            missing_categories="$(
+              jq -cn \
+                --argjson expected "$expected_categories" \
+                --argjson analyses "$analyses" \
+                '$expected - [$analyses[].category]'
+            )"
+            if [ "$(jq 'length' <<<"$missing_categories")" -ne 0 ]; then
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "::error::Missing required CodeQL categories for exact release target ${TARGET_SHA}: $(jq -r 'join(", ")' <<<"$missing_categories")." >&2
+                exit 1
+              fi
+              echo "Waiting for required CodeQL categories on exact target ${TARGET_SHA}: $(jq -r 'join(", ")' <<<"$missing_categories")."
+              sleep "$poll_seconds"
+              continue
+            fi
+
             jq -r '
               .[] |
               "CodeQL analysis \(.id): key=\(.analysis_key // "") category=\(.category // "") error=\(.error // "") warning=\(.warning // "") rules=\(.rules_count // "missing") results=\(.results_count // "missing")"
@@ -504,7 +527,7 @@ jobs:
               exit 1
             fi
 
-            echo "Verified zero-result CodeQL analyses for exact release target ${TARGET_SHA}."
+            echo "Verified all required zero-result CodeQL categories for exact release target ${TARGET_SHA}."
             break
           done
       - name: Extract release notes from CHANGELOG.md

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,8 @@ on:
 permissions: write-all
 concurrency:
   group: codeql-${{ github.ref }}
-  cancel-in-progress: true
+  queue: max
+  cancel-in-progress: false
 jobs:
   analyze:
     permissions: write-all

--- a/.github/workflows/format-public.yml
+++ b/.github/workflows/format-public.yml
@@ -49,4 +49,5 @@ jobs:
     timeout-minutes: 15
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  queue: max
+  cancel-in-progress: false

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,7 +9,8 @@ on:
   workflow_dispatch:
 concurrency:
   group: scorecard-${{ github.ref }}
-  cancel-in-progress: true
+  queue: max
+  cancel-in-progress: false
 permissions: write-all
 
 jobs:

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -10,7 +10,8 @@ permissions: write-all
 
 concurrency:
   group: socket-scan-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  queue: max
+  cancel-in-progress: false
 
 jobs:
   socket-security:


### PR DESCRIPTION
## Contexto

Follow-up do recovery de auto-release já incorporado em `main`. Esta alteração fecha lacunas de evidência sem rerodar historicamente workflows cancelados.

## Alterações

- Busca o arquivo de versão do SHA-alvo remoto pela Contents API autenticada, em vez de depender da presença do objeto no checkout local.
- Exige as duas categorias CodeQL configuradas no SHA exato: `/language:actions` e `/language:javascript-typescript`.
- Mantém polling enquanto uma das categorias ainda não foi publicada; ambas continuam sujeitas às validações de erro, aviso, regras e zero resultados.
- Configura `queue: max` e `cancel-in-progress: false` nos gates sem efeito de deploy: CodeQL, Format Public, Socket Security e Scorecard.
- Preserva `permissions: write-all` no workflow e em todos os jobs afetados.

## Limites de segurança

- Não existe chamada a `actions/runs/{id}/rerun`: runs historicamente cancelados continuam bloqueantes.
- `deploy.yml` permanece com `cancel-in-progress: false`, mas sem fila longa. Isso evita executar posteriormente um deploy antigo fora de ordem e causar rollback.
- Falhas, timeouts e cancelamentos continuam fail-closed no auto-release.

## Validação

- `git diff --check`
- parse YAML de todos os arquivos alterados
- sintaxe dos blocos Bash
- invariantes de `permissions: write-all` e de concorrência
- execução real da prova CodeQL contra um SHA histórico com ambas as categorias
- Contents API comparada byte a byte com o mesmo arquivo no commit remoto
- Zizmor 1.28.0: zero achados
- Actionlint 1.7.12: somente os falsos positivos conhecidos para o campo oficial `concurrency.queue: max`

