### PR TITLE
ci: roll out guarded Dependabot controller

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,6 +78,13 @@ updates:
       interval: "daily"
       time: "01:00"
       timezone: "America/Los_Angeles"
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "pre-commit"
     directory: "/"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -3,7 +3,6 @@ name: Dependabot Automerge
 on:
   workflow_run:
     workflows:
-      - CI
       - CodeQL
       - Dependency Review
       - Public Format
@@ -35,7 +34,7 @@ jobs:
             api.github.com:443
 
       - name: Process one guarded queue mutation
-        uses: LCV-Ideas-Software/.github/dependabot-automerge@c846bc77cbeb38dcf5fb4b8c798dc75227b65f04
+        uses: LCV-Ideas-Software/.github/dependabot-automerge@06078610da5edd1c6d020db205c69d3cd580fcf9
         with:
           github_token: ${{ github.token }}
           automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## O que muda

- fixa o controlador reutilizável do Dependabot no SHA revisado `06078610da5edd1c6d020db205c69d3cd580fcf9`;
- remove do gatilho `workflow_run` o workflow inexistente `CI`, mantendo todos os gatilhos reais e as permissões `write-all` no workflow e no job;
- completa a padronização do bloco npm da raiz com labels, prefixo de commit e limite de PRs, sem alterar versões nem lockfiles.

## Causa raiz e segurança

O `Dependabot Updates` run 29934237276 não falhou em código da aplicação: o Secure Registry da StepSecurity devolveu 404 apenas para o tarball `@tailwindcss/oxide-wasm32-wasi@4.3.3` durante a tentativa de atualizar `@tailwindcss/vite`. O tarball existe no npm público, mas este PR não contorna nem reduz o gate do Secure Registry.

O controlador é API-only: não faz checkout nem executa código do PR. O Auto PR Request permanece desativado durante este rollout.

## Validação

- instalação limpa raiz + frontend;
- ESLint raiz/frontend, Prettier e Biome;
- 54 arquivos / 296 testes no Node 24 do CI;
- Vite/TypeScript build;
- Wrangler `latest` 4.113.0, assinaturas/attestations verificadas, Pages Functions compiladas sem deploy;
- todos os 10 workflows / 11 jobs com `permissions: write-all`;
- YAML válido, zizmor 1.28.0 sem findings e `git diff --check` limpo;
- comentário P1 do `chatgpt-codex-connector` no PR #222 confirmado como tratado e thread resolvida.