### PR TITLE
ci: align Dependabot with registry cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,8 @@ updates:
       prefix: "deps"
       include: "scope"
     versioning-strategy: increase
+    cooldown:
+      default-days: 10
     groups:
       react:
         patterns:


### PR DESCRIPTION
## O que muda

- alinha o updater npm de `/astrologo-frontend` ao cooldown padrão/recomendado de 10 dias do StepSecurity Secure Registry;
- não altera dependências, lockfiles, versões da aplicação nem o roteamento pelo Secure Registry;
- não aplica cooldown às atualizações de segurança (o GitHub as processa imediatamente).

## Causa raiz reproduzida

Os runs [29934237276](https://github.com/LCV-Ideas-Software/astrologo-app/actions/runs/29934237276) e [29972789227](https://github.com/LCV-Ideas-Software/astrologo-app/actions/runs/29972789227) falharam de forma idêntica ao tentar atualizar `@tailwindcss/vite` para 4.3.3:

- metadata de `@tailwindcss/oxide-wasm32-wasi`: HTTP 200 no Secure Registry;
- tarball `oxide-wasm32-wasi-4.3.3.tgz`: HTTP 404 no Secure Registry;
- o mesmo tarball existe no npm público.

O GitHub passou a usar cooldown padrão de 3 dias, enquanto o StepSecurity recomenda e usa 10 dias por padrão. Assim, o Dependabot considera uma versão elegível antes de o registry permitir sua instalação.

Fontes oficiais:

- https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/
- https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates
- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
- https://www.stepsecurity.io/blog/introducing-secure-registry-install-time-defense-for-the-npm-supply-chain

## Validação local

- YAML + asserção de `cooldown.default-days == 10`;
- Prettier;
- ESLint raiz e frontend;
- Biome (126 arquivos; apenas info preexistente de schema 2.5.4 vs CLI 2.5.5);
- 54 arquivos / 296 testes no Node 24 do CI;
- TypeScript + Vite build (1.936 módulos);
- verificação de executáveis rastreados;
- zizmor 1.28.0 sem findings;
- assinatura GPG válida e `git diff --check` limpo.

O controlador do Dependabot está ativo. O Auto PR Request permanece desativado até a conclusão deste rollout.