### PR TITLE
fix(deps): update brace-expansion to 5.0.8

### DIFF
--- a/astrologo-frontend/package-lock.json
+++ b/astrologo-frontend/package-lock.json
@@ -3330,16 +3330,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -828,16 +828,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {


### PR DESCRIPTION
## Summary

- updates `brace-expansion` from 5.0.7 to the current patched 5.0.8 in both npm lockfiles
- closes the vulnerable `eslint > minimatch > brace-expansion` paths reported by Scorecard
- changes no application source or direct dependency range

Security advisory: GHSA-mh99-v99m-4gvg.

## Verification

- fresh `npm ci` in the root and frontend
- `npm audit --audit-level=high`: 0 vulnerabilities in both trees
- root lint and public-format check pass
- frontend ESLint and Biome pass
- focused protocol test: 7/7 pass
- full frontend suite: 54 files, 296 tests pass
- Vite 8.1.5 production build passes

One full-suite run executed under parallel machine contention timed out at the existing 5 s limit in one test; the same test passed alone in 2.27 s and the complete suite then passed without contention.