### PR TITLE
Fix Scorecard repository policy baseline

### DIFF
--- a/.github/scripts/enforce-scorecard.mjs
+++ b/.github/scripts/enforce-scorecard.mjs
@@ -25,11 +25,14 @@ function location(result) {
   return result?.locations?.[0]?.physicalLocation ?? {};
 }
 
-function hasOnlyKeys(object, keys) {
+function hasExactKeys(object, keys) {
   if (object === null || typeof object !== "object" || Array.isArray(object)) {
     return false;
   }
-  return Object.keys(object).every((key) => keys.has(key));
+  const objectKeys = Object.keys(object);
+  return (
+    objectKeys.length === keys.size && objectKeys.every((key) => keys.has(key))
+  );
 }
 
 function isRepositoryPolicyLocation(physicalLocation) {
@@ -46,27 +49,47 @@ function hasCanonicalRepositoryPolicyLocation(result) {
     return false;
   }
   const [entry] = result.locations;
-  if (!hasOnlyKeys(entry, new Set(["physicalLocation"]))) {
+  if (!hasExactKeys(entry, new Set(["physicalLocation"]))) {
     return false;
   }
 
   const physicalLocation = entry.physicalLocation;
-  if (!hasOnlyKeys(physicalLocation, new Set(["artifactLocation", "region"]))) {
+  if (
+    !hasExactKeys(physicalLocation, new Set(["artifactLocation", "region"]))
+  ) {
     return false;
   }
   if (
-    !hasOnlyKeys(
+    !hasExactKeys(
       physicalLocation.artifactLocation,
       new Set(["uri", "uriBaseId"]),
     )
   ) {
     return false;
   }
-  if (!hasOnlyKeys(physicalLocation.region, new Set(["startLine"]))) {
+  if (!hasExactKeys(physicalLocation.region, new Set(["startLine"]))) {
     return false;
   }
 
   return isRepositoryPolicyLocation(physicalLocation);
+}
+
+function hasCanonicalRepositoryPolicyResult(result) {
+  if (
+    !hasExactKeys(
+      result,
+      new Set(["ruleId", "ruleIndex", "message", "locations"]),
+    )
+  ) {
+    return false;
+  }
+  if (!Number.isSafeInteger(result.ruleIndex) || result.ruleIndex < 0) {
+    return false;
+  }
+  if (!hasExactKeys(result.message, new Set(["text"]))) {
+    return false;
+  }
+  return hasCanonicalRepositoryPolicyLocation(result);
 }
 
 function tokenPermissionsMessages(workflowFile) {
@@ -106,20 +129,22 @@ export function isApprovedFinding(result) {
     );
   }
 
-  // These are repository-level observations of the intentionally reviewless
-  // automation policy, not file-backed defects. Keep their live signatures
-  // narrow: any new warning, location drift, non-zero review numerator, or
-  // changed badge state falls through and fails the gate.
-  if (!hasCanonicalRepositoryPolicyLocation(result)) {
-    return false;
-  }
   if (result?.ruleId === "BranchProtectionID") {
+    if (!hasCanonicalRepositoryPolicyResult(result)) {
+      return false;
+    }
     return message === BRANCH_PROTECTION_MESSAGE;
   }
   if (result?.ruleId === "CodeReviewID") {
+    if (!hasCanonicalRepositoryPolicyResult(result)) {
+      return false;
+    }
     return CODE_REVIEW_MESSAGE.test(message);
   }
   if (result?.ruleId === "CIIBestPracticesID") {
+    if (!hasCanonicalRepositoryPolicyResult(result)) {
+      return false;
+    }
     return message === CII_BEST_PRACTICES_MESSAGE;
   }
 

--- a/.github/scripts/enforce-scorecard.mjs
+++ b/.github/scripts/enforce-scorecard.mjs
@@ -8,9 +8,30 @@ const APPROVED_WRANGLER_SNIPPETS = new Set([
   'npm install --prefix "$wrangler_prefix" --save-exact --ignore-scripts --no-audit --no-fund wrangler@latest',
   'npm install --prefix "$wrangler_prefix" --ignore-scripts --no-audit --no-fund',
 ]);
+const REPOSITORY_POLICY_PATH = "no file associated with this alert";
+const BRANCH_PROTECTION_MESSAGE = `score is 3: branch protection is not maximal on development and all release branches:
+Warn: 'stale review dismissal' is disabled on branch 'main'
+Warn: branch 'main' does not require approvers
+Warn: codeowners review is not required on branch 'main'
+Warn: 'last push approval' is disabled on branch 'main'
+Warn: no status checks found to merge onto branch 'main'
+Click Remediation section below to solve this issue`;
+const CODE_REVIEW_MESSAGE =
+  /^score is 0: Found 0\/[1-9]\d* approved changesets -- score normalized to 0\nClick Remediation section below to solve this issue$/;
+const CII_BEST_PRACTICES_MESSAGE =
+  "score is 0: no effort to earn an OpenSSF best practices badge detected\nClick Remediation section below to solve this issue";
 
 function location(result) {
   return result?.locations?.[0]?.physicalLocation ?? {};
+}
+
+function isRepositoryPolicyLocation(physicalLocation) {
+  return (
+    physicalLocation.artifactLocation?.uri === REPOSITORY_POLICY_PATH &&
+    physicalLocation.artifactLocation?.uriBaseId === "%SRCROOT%" &&
+    physicalLocation.region?.startLine === 1 &&
+    physicalLocation.region?.snippet === undefined
+  );
 }
 
 function tokenPermissionsMessages(workflowFile) {
@@ -48,6 +69,23 @@ export function isApprovedFinding(result) {
       message === PINNED_DEPENDENCY_MESSAGE &&
       APPROVED_WRANGLER_SNIPPETS.has(snippet)
     );
+  }
+
+  // These are repository-level observations of the intentionally reviewless
+  // automation policy, not file-backed defects. Keep their live signatures
+  // narrow: any new warning, location drift, non-zero review numerator, or
+  // changed badge state falls through and fails the gate.
+  if (!isRepositoryPolicyLocation(physicalLocation)) {
+    return false;
+  }
+  if (result?.ruleId === "BranchProtectionID") {
+    return message === BRANCH_PROTECTION_MESSAGE;
+  }
+  if (result?.ruleId === "CodeReviewID") {
+    return CODE_REVIEW_MESSAGE.test(message);
+  }
+  if (result?.ruleId === "CIIBestPracticesID") {
+    return message === CII_BEST_PRACTICES_MESSAGE;
   }
 
   return false;

--- a/.github/scripts/enforce-scorecard.mjs
+++ b/.github/scripts/enforce-scorecard.mjs
@@ -55,7 +55,10 @@ function hasCanonicalRepositoryPolicyLocation(result) {
     return false;
   }
   if (
-    !hasOnlyKeys(physicalLocation.artifactLocation, new Set(["uri", "uriBaseId"]))
+    !hasOnlyKeys(
+      physicalLocation.artifactLocation,
+      new Set(["uri", "uriBaseId"]),
+    )
   ) {
     return false;
   }

--- a/.github/scripts/enforce-scorecard.mjs
+++ b/.github/scripts/enforce-scorecard.mjs
@@ -25,6 +25,13 @@ function location(result) {
   return result?.locations?.[0]?.physicalLocation ?? {};
 }
 
+function hasOnlyKeys(object, keys) {
+  if (object === null || typeof object !== "object" || Array.isArray(object)) {
+    return false;
+  }
+  return Object.keys(object).every((key) => keys.has(key));
+}
+
 function isRepositoryPolicyLocation(physicalLocation) {
   return (
     physicalLocation.artifactLocation?.uri === REPOSITORY_POLICY_PATH &&
@@ -32,6 +39,31 @@ function isRepositoryPolicyLocation(physicalLocation) {
     physicalLocation.region?.startLine === 1 &&
     physicalLocation.region?.snippet === undefined
   );
+}
+
+function hasCanonicalRepositoryPolicyLocation(result) {
+  if (!Array.isArray(result?.locations) || result.locations.length !== 1) {
+    return false;
+  }
+  const [entry] = result.locations;
+  if (!hasOnlyKeys(entry, new Set(["physicalLocation"]))) {
+    return false;
+  }
+
+  const physicalLocation = entry.physicalLocation;
+  if (!hasOnlyKeys(physicalLocation, new Set(["artifactLocation", "region"]))) {
+    return false;
+  }
+  if (
+    !hasOnlyKeys(physicalLocation.artifactLocation, new Set(["uri", "uriBaseId"]))
+  ) {
+    return false;
+  }
+  if (!hasOnlyKeys(physicalLocation.region, new Set(["startLine"]))) {
+    return false;
+  }
+
+  return isRepositoryPolicyLocation(physicalLocation);
 }
 
 function tokenPermissionsMessages(workflowFile) {
@@ -75,7 +107,7 @@ export function isApprovedFinding(result) {
   // automation policy, not file-backed defects. Keep their live signatures
   // narrow: any new warning, location drift, non-zero review numerator, or
   // changed badge state falls through and fails the gate.
-  if (!isRepositoryPolicyLocation(physicalLocation)) {
+  if (!hasCanonicalRepositoryPolicyLocation(result)) {
     return false;
   }
   if (result?.ruleId === "BranchProtectionID") {

--- a/.github/scripts/enforce-scorecard.test.mjs
+++ b/.github/scripts/enforce-scorecard.test.mjs
@@ -44,9 +44,10 @@ function finding(ruleId, { path, snippet, message } = {}) {
   };
 }
 
-function repositoryPolicyFinding(ruleId, message) {
+function repositoryPolicyFinding(ruleId, message, ruleIndex = 0) {
   return {
     ruleId,
+    ruleIndex,
     message: { text: message },
     locations: [
       {
@@ -171,6 +172,20 @@ test("fails closed when a repository-policy signature drifts", () => {
   extraArtifactField.locations[0].physicalLocation.artifactLocation.index = 0;
   const extraRegionField = structuredClone(exactCiiBestPracticesFinding);
   extraRegionField.locations[0].physicalLocation.region.endLine = 1;
+  const extraResultField = structuredClone(exactBranchProtectionFinding);
+  extraResultField.level = "warning";
+  const extraResultSuppressions = structuredClone(exactCodeReviewFinding);
+  extraResultSuppressions.suppressions = [{ kind: "inSource" }];
+  const extraMessageField = structuredClone(exactCiiBestPracticesFinding);
+  extraMessageField.message.markdown = "unexpected";
+  const missingRuleIndex = structuredClone(exactBranchProtectionFinding);
+  delete missingRuleIndex.ruleIndex;
+  const negativeRuleIndex = structuredClone(exactCodeReviewFinding);
+  negativeRuleIndex.ruleIndex = -1;
+  const nonIntegerRuleIndex = structuredClone(exactCiiBestPracticesFinding);
+  nonIntegerRuleIndex.ruleIndex = 0.5;
+  const unsafeRuleIndex = structuredClone(exactBranchProtectionFinding);
+  unsafeRuleIndex.ruleIndex = Number.MAX_SAFE_INTEGER + 1;
 
   for (const changed of [
     repositoryPolicyFinding(
@@ -207,6 +222,13 @@ test("fails closed when a repository-policy signature drifts", () => {
     extraLocationField,
     extraArtifactField,
     extraRegionField,
+    extraResultField,
+    extraResultSuppressions,
+    extraMessageField,
+    missingRuleIndex,
+    negativeRuleIndex,
+    nonIntegerRuleIndex,
+    unsafeRuleIndex,
   ]) {
     assert.equal(isApprovedFinding(changed), false);
   }

--- a/.github/scripts/enforce-scorecard.test.mjs
+++ b/.github/scripts/enforce-scorecard.test.mjs
@@ -145,11 +145,7 @@ test("accepts only the intentional repository-policy signatures", () => {
 });
 
 test("rejects every non-policy Scorecard result, including binary artifacts", () => {
-  const ruleIds = [
-    "FuzzingID",
-    "BinaryArtifactsID",
-    "VulnerabilitiesID",
-  ];
+  const ruleIds = ["FuzzingID", "BinaryArtifactsID", "VulnerabilitiesID"];
   assert.deepEqual(
     unapprovedFindings(sarif(ruleIds.map((ruleId) => finding(ruleId)))).map(
       ({ ruleId }) => ruleId,

--- a/.github/scripts/enforce-scorecard.test.mjs
+++ b/.github/scripts/enforce-scorecard.test.mjs
@@ -167,6 +167,14 @@ test("fails closed when a repository-policy signature drifts", () => {
   const changedBase = structuredClone(exactCiiBestPracticesFinding);
   changedBase.locations[0].physicalLocation.artifactLocation.uriBaseId =
     "%OTHERROOT%";
+  const extraLocation = structuredClone(exactBranchProtectionFinding);
+  extraLocation.locations.push(structuredClone(extraLocation.locations[0]));
+  const extraLocationField = structuredClone(exactCodeReviewFinding);
+  extraLocationField.locations[0].analysisTarget = { uri: "ignored" };
+  const extraArtifactField = structuredClone(exactBranchProtectionFinding);
+  extraArtifactField.locations[0].physicalLocation.artifactLocation.index = 0;
+  const extraRegionField = structuredClone(exactCiiBestPracticesFinding);
+  extraRegionField.locations[0].physicalLocation.region.endLine = 1;
 
   for (const changed of [
     repositoryPolicyFinding(
@@ -199,6 +207,10 @@ test("fails closed when a repository-policy signature drifts", () => {
     changedLocation,
     changedLine,
     changedBase,
+    extraLocation,
+    extraLocationField,
+    extraArtifactField,
+    extraRegionField,
   ]) {
     assert.equal(isApprovedFinding(changed), false);
   }

--- a/.github/scripts/enforce-scorecard.test.mjs
+++ b/.github/scripts/enforce-scorecard.test.mjs
@@ -17,6 +17,15 @@ NOTE: If you want to resolve multiple issues at once, you can visit [https://app
 Click Remediation section below for further remediation help`;
 const PINNED_MESSAGE =
   "score is 8: npmCommand not pinned by hash\nClick Remediation section below to solve this issue";
+const BRANCH_PROTECTION_MESSAGE = `score is 3: branch protection is not maximal on development and all release branches:
+Warn: 'stale review dismissal' is disabled on branch 'main'
+Warn: branch 'main' does not require approvers
+Warn: codeowners review is not required on branch 'main'
+Warn: 'last push approval' is disabled on branch 'main'
+Warn: no status checks found to merge onto branch 'main'
+Click Remediation section below to solve this issue`;
+const CII_BEST_PRACTICES_MESSAGE =
+  "score is 0: no effort to earn an OpenSSF best practices badge detected\nClick Remediation section below to solve this issue";
 
 function finding(ruleId, { path, snippet, message } = {}) {
   return {
@@ -29,6 +38,24 @@ function finding(ruleId, { path, snippet, message } = {}) {
             uri: path ?? "no file associated with this alert",
           },
           region: { startLine: 1, snippet: { text: snippet ?? "" } },
+        },
+      },
+    ],
+  };
+}
+
+function repositoryPolicyFinding(ruleId, message) {
+  return {
+    ruleId,
+    message: { text: message },
+    locations: [
+      {
+        physicalLocation: {
+          artifactLocation: {
+            uri: "no file associated with this alert",
+            uriBaseId: "%SRCROOT%",
+          },
+          region: { startLine: 1 },
         },
       },
     ],
@@ -61,6 +88,18 @@ const exactWranglerReconcileFinding = finding("PinnedDependenciesID", {
     'npm install --prefix "$wrangler_prefix" --ignore-scripts --no-audit --no-fund',
   message: PINNED_MESSAGE,
 });
+const exactBranchProtectionFinding = repositoryPolicyFinding(
+  "BranchProtectionID",
+  BRANCH_PROTECTION_MESSAGE,
+);
+const exactCodeReviewFinding = repositoryPolicyFinding(
+  "CodeReviewID",
+  "score is 0: Found 0/18 approved changesets -- score normalized to 0\nClick Remediation section below to solve this issue",
+);
+const exactCiiBestPracticesFinding = repositoryPolicyFinding(
+  "CIIBestPracticesID",
+  CII_BEST_PRACTICES_MESSAGE,
+);
 
 test("accepts an empty result set", () => {
   assert.deepEqual(unapprovedFindings(sarif([])), []);
@@ -80,12 +119,34 @@ test("accepts only the exact write-all and Wrangler policy signatures", () => {
   );
 });
 
+test("accepts only the intentional repository-policy signatures", () => {
+  assert.deepEqual(
+    unapprovedFindings(
+      sarif([
+        exactBranchProtectionFinding,
+        exactCodeReviewFinding,
+        exactCiiBestPracticesFinding,
+      ]),
+    ),
+    [],
+  );
+
+  for (const denominator of [1, 18, 30]) {
+    assert.equal(
+      isApprovedFinding(
+        repositoryPolicyFinding(
+          "CodeReviewID",
+          `score is 0: Found 0/${denominator} approved changesets -- score normalized to 0\nClick Remediation section below to solve this issue`,
+        ),
+      ),
+      true,
+    );
+  }
+});
+
 test("rejects every non-policy Scorecard result, including binary artifacts", () => {
   const ruleIds = [
-    "BranchProtectionID",
     "FuzzingID",
-    "CodeReviewID",
-    "CIIBestPracticesID",
     "BinaryArtifactsID",
     "VulnerabilitiesID",
   ];
@@ -95,6 +156,52 @@ test("rejects every non-policy Scorecard result, including binary artifacts", ()
     ),
     ruleIds,
   );
+});
+
+test("fails closed when a repository-policy signature drifts", () => {
+  const changedLocation = structuredClone(exactBranchProtectionFinding);
+  changedLocation.locations[0].physicalLocation.artifactLocation.uri =
+    ".github/workflows/scorecard.yml";
+  const changedLine = structuredClone(exactCodeReviewFinding);
+  changedLine.locations[0].physicalLocation.region.startLine = 2;
+  const changedBase = structuredClone(exactCiiBestPracticesFinding);
+  changedBase.locations[0].physicalLocation.artifactLocation.uriBaseId =
+    "%OTHERROOT%";
+
+  for (const changed of [
+    repositoryPolicyFinding(
+      "BranchProtectionID",
+      `${BRANCH_PROTECTION_MESSAGE}\nWarn: an additional protection regressed`,
+    ),
+    repositoryPolicyFinding(
+      "BranchProtectionID",
+      BRANCH_PROTECTION_MESSAGE.replace(
+        "Warn: no status checks found to merge onto branch 'main'\n",
+        "",
+      ),
+    ),
+    repositoryPolicyFinding(
+      "CodeReviewID",
+      "score is 0: Found 1/18 approved changesets -- score normalized to 0\nClick Remediation section below to solve this issue",
+    ),
+    repositoryPolicyFinding(
+      "CodeReviewID",
+      "score is 0: Found 0/0 approved changesets -- score normalized to 0\nClick Remediation section below to solve this issue",
+    ),
+    repositoryPolicyFinding(
+      "CodeReviewID",
+      "score is 0: Found 0/018 approved changesets -- score normalized to 0\nClick Remediation section below to solve this issue",
+    ),
+    repositoryPolicyFinding(
+      "CIIBestPracticesID",
+      `${CII_BEST_PRACTICES_MESSAGE} altered`,
+    ),
+    changedLocation,
+    changedLine,
+    changedBase,
+  ]) {
+    assert.equal(isApprovedFinding(changed), false);
+  }
 });
 
 test("fails closed when any write-all signature field changes", () => {

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
   zizmor:
     name: Run zizmor
     permissions: write-all
-    uses: LCV-Ideas-Software/.github/.github/workflows/zizmor.yml@ac3d4ad22073ee419cb9b861c38fe7bfa93b132a # v1.0.2
+    uses: LCV-Ideas-Software/.github/.github/workflows/zizmor.yml@4058fad11eca7c2eb4e9296108667ef6199a6356 # v2.0.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
   zizmor:
     name: Run zizmor
     permissions: write-all
-    uses: LCV-Ideas-Software/.github/.github/workflows/zizmor.yml@4058fad11eca7c2eb4e9296108667ef6199a6356 # v2.0.0
+    uses: LCV-Ideas-Software/.github/.github/workflows/zizmor.yml@ac3d4ad22073ee419cb9b861c38fe7bfa93b132a # v1.0.2


### PR DESCRIPTION
## O que mudou

- reconhece somente as assinaturas SARIF atuais e completas de `BranchProtectionID`, `CodeReviewID` e `CIIBestPracticesID` que refletem a governança de repositório deliberada
- mantém `CodeReviewID` restrito a `0/N`, com denominador inteiro positivo e mensagem integral
- mantém todo finding novo, warning adicional, localização alterada ou mudança semântica em modo fail-closed
- adiciona testes positivos e de mutação para impedir regressões para allowlist por `ruleId`

## Causa-raiz

O PR #255 passou no evento de pull request, mas os três findings de nível de repositório só foram produzidos no `push` confiável em `main`. O novo gate estrito rejeitou esses resultados na primeira execução e o Auto-release abortou corretamente em cascata.

## Validação

- `node --test .github/scripts/enforce-scorecard.test.mjs` — 8/8
- SARIF real do run `31312442867` — aceito
- seis mutações do SARIF real — todas rejeitadas
- root ESLint e Prettier — verdes
- frontend ESLint e Biome — verdes
- Vitest — 56 arquivos, 325 testes
- Vite production build e Wrangler Functions build — verdes
- `npm audit --omit=dev` nos dois lockfiles — zero vulnerabilidades
- inventário live pré-PR: zero Code Scanning, Dependabot, Secret Scanning e Code Quality findings abertos

## Limites

Este PR não altera rulesets, branch protection, tags, releases nem dismissals. A release `v02.24.00` deverá ser reconciliada pelo workflow idempotente somente depois que o patch estiver em `main` e os gates do SHA exato concluírem verdes.