### PR TITLE
Fix native merge-group security gates

### DIFF
--- a/.github/scripts/scorecard-workflow.test.mjs
+++ b/.github/scripts/scorecard-workflow.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const SCORECARD_WORKFLOW_URL = new URL(
+  "../workflows/scorecard.yml",
+  import.meta.url,
+);
+const ZIZMOR_WORKFLOW_URL = new URL("../workflows/zizmor.yml", import.meta.url);
+const SCORECARD_MERGE_GROUP_IMAGE =
+  "ghcr.io/ossf/scorecard-action:v2.4.4@sha256:ae5104dd3cc28466ebeb11144354be4cac4b7ff829654f9fab89021d71c46670";
+const CENTRAL_ZIZMOR_V2 =
+  "LCV-Ideas-Software/.github/.github/workflows/zizmor.yml@4058fad11eca7c2eb4e9296108667ef6199a6356 # v2.0.0";
+
+function namedStep(workflow, name) {
+  const lines = workflow.split(/\r?\n/);
+  const start = lines.indexOf(`      - name: ${name}`);
+  assert.notEqual(start, -1, `missing workflow step: ${name}`);
+
+  let end = start + 1;
+  while (end < lines.length && !lines[end].startsWith("      - ")) end += 1;
+  return lines.slice(start, end).join("\n");
+}
+
+test("pull requests and merge groups produce Scorecard SARIF through the proven execution modes", async () => {
+  const workflow = await readFile(SCORECARD_WORKFLOW_URL, "utf8");
+
+  assert.match(workflow, /\n  pull_request:\n\s+branches: \["main"\]/);
+  assert.match(workflow, /\n  merge_group:\n\s+types:\n\s+- checks_requested/);
+
+  const regression = namedStep(workflow, "Test Scorecard policy enforcement");
+  assert.match(
+    regression,
+    /node --test\s+\.github\/scripts\/enforce-scorecard\.test\.mjs\s+\.github\/scripts\/scorecard-workflow\.test\.mjs/,
+  );
+  assert.doesNotMatch(regression, /continue-on-error:/);
+
+  const supported = namedStep(workflow, "Run Scorecard on supported events");
+  assert.match(supported, /if: github\.event_name != 'merge_group'/);
+  assert.match(supported, /uses: ossf\/scorecard-action@[0-9a-f]{40}/);
+  assert.match(supported, /results_file: scorecard-results\.sarif/);
+  assert.doesNotMatch(supported, /continue-on-error:/);
+
+  const mergeGroup = namedStep(workflow, "Run Scorecard on merge group");
+  assert.match(mergeGroup, /if: github\.event_name == 'merge_group'/);
+  assert.deepEqual(
+    mergeGroup.match(
+      /ghcr\.io\/ossf\/scorecard-action:v\d+\.\d+\.\d+@sha256:[0-9a-f]{64}/g,
+    ),
+    [SCORECARD_MERGE_GROUP_IMAGE],
+  );
+  assert.match(mergeGroup, /--env GITHUB_EVENT_NAME=pull_request/);
+  assert.match(mergeGroup, /--env INPUT_RESULTS_FILE/);
+  assert.match(mergeGroup, /INPUT_RESULTS_FILE: scorecard-results\.sarif/);
+  assert.match(mergeGroup, /INPUT_REPO_TOKEN: local-merge-group-no-credential/);
+  assert.match(
+    mergeGroup,
+    /--volume "\$GITHUB_EVENT_PATH:\/github\/event\.json:ro"/,
+  );
+  assert.match(mergeGroup, /--volume "\$GITHUB_WORKSPACE:\/github\/workspace"/);
+  assert.match(mergeGroup, /--env INPUT_REPO_TOKEN/);
+  assert.doesNotMatch(mergeGroup, /\$\{\{ github\.token \}\}/);
+  assert.doesNotMatch(mergeGroup, /GITHUB_AUTH_TOKEN/);
+  assert.doesNotMatch(mergeGroup, /INPUT_INTERNAL_DEFAULT_TOKEN/);
+  assert.doesNotMatch(mergeGroup, /continue-on-error:/);
+
+  const requireSarif = namedStep(workflow, "Require Scorecard SARIF");
+  assert.match(requireSarif, /test -s scorecard-results\.sarif/);
+  assert.doesNotMatch(requireSarif, /if:/);
+
+  const enforcement = namedStep(workflow, "Enforce approved Scorecard policy");
+  assert.match(
+    enforcement,
+    /node \.github\/scripts\/enforce-scorecard\.mjs scorecard-results\.sarif/,
+  );
+  assert.doesNotMatch(enforcement, /continue-on-error:/);
+});
+
+test("Zizmor delegates to the immutable central v2 workflow", async () => {
+  const workflow = await readFile(ZIZMOR_WORKFLOW_URL, "utf8");
+  assert.equal(
+    workflow.match(
+      /LCV-Ideas-Software\/\.github\/\.github\/workflows\/zizmor\.yml@[0-9a-f]{40} # v\d+\.\d+\.\d+/g,
+    )?.[0],
+    CENTRAL_ZIZMOR_V2,
+  );
+});

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,15 +26,50 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Set up Node.js for the workflow regression
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
       - name: Test Scorecard policy enforcement
-        run: node --test .github/scripts/enforce-scorecard.test.mjs
-      - uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        run: >-
+          node --test
+          .github/scripts/enforce-scorecard.test.mjs
+          .github/scripts/scorecard-workflow.test.mjs
+      - name: Run Scorecard on supported events
+        if: github.event_name != 'merge_group'
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
           # OpenSSF's publication API rejects workflows with organization-mandated write-all.
           # SARIF and artifacts remain enabled below.
           publish_results: false
+      - name: Run Scorecard on merge group
+        if: github.event_name == 'merge_group'
+        shell: bash
+        env:
+          # v2.4.4 validates token presence before selecting its tokenless local client.
+          INPUT_REPO_TOKEN: local-merge-group-no-credential
+          INPUT_RESULTS_FILE: scorecard-results.sarif
+          INPUT_RESULTS_FORMAT: sarif
+        run: |
+          set -euo pipefail
+          # v2.4.4 supports local candidate analysis only through its pull_request mode.
+          # Run that exact official image over GitHub's checked-out merge-group commit.
+          docker run --rm \
+            --volume "$GITHUB_EVENT_PATH:/github/event.json:ro" \
+            --volume "$GITHUB_WORKSPACE:/github/workspace" \
+            --workdir /github/workspace \
+            --env GITHUB_EVENT_NAME=pull_request \
+            --env GITHUB_EVENT_PATH=/github/event.json \
+            --env GITHUB_WORKSPACE=/github/workspace \
+            --env INPUT_REPO_TOKEN \
+            --env INPUT_RESULTS_FILE \
+            --env INPUT_RESULTS_FORMAT \
+            ghcr.io/ossf/scorecard-action:v2.4.4@sha256:ae5104dd3cc28466ebeb11144354be4cac4b7ff829654f9fab89021d71c46670
+      - name: Require Scorecard SARIF
+        shell: bash
+        run: test -s scorecard-results.sarif
       - name: Upload SARIF artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
   zizmor:
     name: Run zizmor
     permissions: write-all
-    uses: LCV-Ideas-Software/.github/.github/workflows/zizmor.yml@ac3d4ad22073ee419cb9b861c38fe7bfa93b132a # v1.0.2
+    uses: LCV-Ideas-Software/.github/.github/workflows/zizmor.yml@4058fad11eca7c2eb4e9296108667ef6199a6356 # v2.0.0


### PR DESCRIPTION
## Summary
- run OpenSSF Scorecard v2.4.4 in its proven tokenless local mode for GitHub merge-group candidates, using the official image pinned by digest
- require non-empty SARIF and retain the exact fail-closed repository policy enforcement
- adopt the immutable central Zizmor v2.0.0 caller
- add regression tests for both workflow contracts

## Validation
- node --test .github/scripts/enforce-scorecard.test.mjs .github/scripts/scorecard-workflow.test.mjs (10/10)
- prettier check and git diff --check
- zizmor 1.29.0 offline auditor: zero active findings (3 documented ignores)
- gitleaks .github: zero leaks
- Public Format-equivalent gate: 56 files / 325 tests, ESLint, Biome, executable-artifact check, Vite build and Pages Functions build

The native controller remains responsible for enabling squash auto-merge. Ruleset activation and the merge-group canary are intentionally coordinated separately after this PR reaches main.