### PR TITLE
Test native merge queue canary

### DIFF
--- a/docs/CANARIO_FILA_MERGE_NATIVA.md
+++ b/docs/CANARIO_FILA_MERGE_NATIVA.md
@@ -1,0 +1,20 @@
+# Canário da fila de merge nativa
+
+Data: 9 de agosto de 2026
+Escopo: governança do GitHub Actions; nenhuma alteração no aplicativo ou no runtime.
+
+Esta alteração exclusivamente documental é a carga inerte usada para validar a fila de merge
+nativa do `astrologo-app`. O canário somente será considerado bem-sucedido se o controlador
+central habilitar o auto-merge por squash para o SHA exato deste pull request e o GitHub criar um
+commit sintético de `merge_group` no qual todos os contextos declarados concluam com sucesso:
+
+- `Dependency Review`;
+- `Check index.html formatting`;
+- `Analyze actions`;
+- `Analyze javascript-typescript`;
+- `OpenSSF Scorecard`;
+- `Reject unverified binary artifacts`;
+- `Run zizmor / Run zizmor`.
+
+Os rulesets permanecem fail-closed: o canário não pode contornar a fila, usar override de
+administrador nem realizar merge por chamada direta à API.


### PR DESCRIPTION
## O que mudou

Adiciona um artefato exclusivamente documental que serve como canário inerte da fila de merge nativa do `astrologo-app`.

## Objetivo

Provar que o controlador central habilita auto-merge por squash para o head exato e que o GitHub produz um SHA sintético de `merge_group` com os sete contextos declarados verdes.

## Escopo

- Somente evidência de governança do GitHub Actions.
- Nenhuma alteração no aplicativo, runtime, dependências, release ou deploy.
- Sem override administrativo, bypass ou chamada direta ao endpoint de merge.

## Validação local

- Prettier no relatório Markdown.
- `git diff --check`.
- Commit GPG assinado `377fa09895183a2b6550d7e8ef7e9266e615cd98`.