### PR TITLE
Fix active queue Scorecard baseline

### DIFF
--- a/.github/scripts/enforce-scorecard.mjs
+++ b/.github/scripts/enforce-scorecard.mjs
@@ -14,7 +14,7 @@ Warn: 'stale review dismissal' is disabled on branch 'main'
 Warn: branch 'main' does not require approvers
 Warn: codeowners review is not required on branch 'main'
 Warn: 'last push approval' is disabled on branch 'main'
-Warn: no status checks found to merge onto branch 'main'
+Warn: 'up-to-date branches' is disabled on branch 'main'
 Click Remediation section below to solve this issue`;
 const CODE_REVIEW_MESSAGE =
   /^score is 0: Found 0\/[1-9]\d* approved changesets -- score normalized to 0\nClick Remediation section below to solve this issue$/;

--- a/.github/scripts/enforce-scorecard.test.mjs
+++ b/.github/scripts/enforce-scorecard.test.mjs
@@ -22,7 +22,7 @@ Warn: 'stale review dismissal' is disabled on branch 'main'
 Warn: branch 'main' does not require approvers
 Warn: codeowners review is not required on branch 'main'
 Warn: 'last push approval' is disabled on branch 'main'
-Warn: no status checks found to merge onto branch 'main'
+Warn: 'up-to-date branches' is disabled on branch 'main'
 Click Remediation section below to solve this issue`;
 const CII_BEST_PRACTICES_MESSAGE =
   "score is 0: no effort to earn an OpenSSF best practices badge detected\nClick Remediation section below to solve this issue";
@@ -195,8 +195,15 @@ test("fails closed when a repository-policy signature drifts", () => {
     repositoryPolicyFinding(
       "BranchProtectionID",
       BRANCH_PROTECTION_MESSAGE.replace(
-        "Warn: no status checks found to merge onto branch 'main'\n",
+        "Warn: 'up-to-date branches' is disabled on branch 'main'\n",
         "",
+      ),
+    ),
+    repositoryPolicyFinding(
+      "BranchProtectionID",
+      BRANCH_PROTECTION_MESSAGE.replace(
+        "Warn: 'up-to-date branches' is disabled on branch 'main'",
+        "Warn: no status checks found to merge onto branch 'main'",
       ),
     ),
     repositoryPolicyFinding(


### PR DESCRIPTION
## Causa raiz

Após a ativação dos status checks nativos, o Scorecard v5.5.0 deixou de produzir `no status checks found to merge onto branch main` e passou a refletir o estado estável da policy: `up-to-date branches is disabled`. O baseline exato permaneceu ligado ao estado pré-ativação e o push de `main` do canário falhou corretamente no run 31319464278.

O SARIF identifica a implementação oficial v5.5.0 e aponta para a documentação do check Branch Protection no commit exato: https://github.com/ossf/scorecard/blob/c395761df6afe1a69e476bc60a013a94bcbc153f/docs/checks.md#branch-protection

## Correção

- Substitui somente a assinatura exata de BranchProtectionID pelo estado pós-ativação.
- Mantém a validação estrutural canônica e todos os demais baselines intactos.
- Rejeita explicitamente a assinatura antiga para evitar uma aceitação dupla ou ampla.

## Escopo

Somente scripts/testes de suporte ao workflow GitHub Actions. Nenhuma alteração no aplicativo, runtime, regras ou bypasses.

## Validação

- Falha TDD reproduzida antes do patch: 6/8 testes, com rejeição do novo finding e aceitação indevida do antigo.
- 10/10 testes do workflow Scorecard após o patch.
- O SARIF real do run 31319464278 passa pelo enforcement corrigido.
- Prettier e `git diff --check` verdes.
- Commit GPG assinado `5730f0eb110fe37eb016834d504d9f31b71dcb90`.