### PR TITLE
feat(ai): seletor de modelos sempre respeitado — v02.25.00

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [v02.25.00] - 2026-08-09
+
+**Seletor de modelos sempre respeitado (diretiva fleet-wide do operador).**
+
+### Alterado
+
+- A tabela `vertexModelCapabilities` deixa de gatear a seleção do modelo: o ID configurado no seletor do admin é usado exatamente como está (validação apenas sintática, pois compõe o path da URL do publisher model). IDs fora da tabela validada recebem limites conservadores (entrada 128 mil tokens pela orquestração; saída 65.535, o menor teto observado entre os modelos validados) — modelos novos nunca são rebaixados silenciosamente na seleção.
+- Fallback para `gemini-3.1-pro-preview` passa a ocorrer apenas em runtime, quando o Vertex responde 404 de publisher model para o modelo selecionado, ANTES de qualquer plano de análise ser persistido (novo módulo `functions/api/_shared/modelAvailability.ts`); um 404 da mint OAuth nunca dispara a troca (`VertexHttpError` agora carrega a operação de origem).
+- `gemini-3.6-flash` entra na tabela de capacidades validadas (teto de saída 65.536, validado empiricamente no endpoint global em 2026-08-09).
+- Planos persistidos por versões anteriores continuam sendo clampados aos limites atuais na retomada, agora preservando o modelo do seletor em vez de reescrevê-lo.
+
 ## [v02.24.00] - 2026-08-08
 
 ### Alterado

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 **Astrólogo** — gerador de mapas astrais e análises esotéricas via integração Gemini AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.
 
-**Status.** Stable. Current release: **v02.24.00**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v02.25.00**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release                              | Scope                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`v02.25.00`**                      | **Seletor de modelos sempre respeitado.** A tabela de capacidades deixa de gatear a seleção: o ID do seletor do admin é usado como configurado e o fallback para o padrão ocorre apenas quando o Vertex responde 404 para o modelo selecionado; `gemini-3.6-flash` entra na tabela validada.                                                          |
 | **`v02.24.00`**                      | **Transporte Vertex AI.** Migra a autenticação da análise para service account com OAuth2 e usa o cliente REST do Vertex AI, preservando prompts, orquestração, saída estruturada, retries e telemetria.                                                                                                                                            |
 | **`v02.23.05`**                      | **Dependency security patch.** Updates the transitive `protobufjs` override used by `@google/genai` to 7.6.5, resolving GHSA-j3f2-48v5-ccww / CVE-2026-59877 without changing application APIs or prompts. |
 | **`v02.23.04`**                      | **Profundidade e iconografia restauradas.** Volta a preservar todos os fragmentos interpretativos e acrescentar a síntese sem teto artificial de extensão; remove somente metodologia e detalhes internos, mantém o fix do 422 e recupera os símbolos pictóricos obrigatórios.                                                                                   |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported status
 
-Latest supported release: v02.24.00. The current main branch is also supported for security fixes until the next release is published.
+Latest supported release: v02.25.00. The current main branch is also supported for security fixes until the next release is published.
 
 ## Reporting a vulnerability
 

--- a/astrologo-frontend/README.md
+++ b/astrologo-frontend/README.md
@@ -19,12 +19,13 @@ Currently, two official plugins are available:
 
 ## Change History
 
-**Status.** Stable. Current release: **v02.24.00**. See [CHANGELOG.md](../CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v02.25.00**. See [CHANGELOG.md](../CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release     | Notes                                                                                                                                                                   |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `v02.25.00` | O seletor de modelos passa a ser sempre respeitado: sem gate de allowlist na seleção; fallback ao padrão só em indisponibilidade real (404 do publisher model); `gemini-3.6-flash` validado na tabela de capacidades. |
 | `v02.24.00` | Migra a autenticação para service account com OAuth2 e substitui o SDK pelo transporte REST do Vertex AI, preservando a orquestração e os contratos de saída. |
 | `v02.23.05` | Atualiza o `protobufjs` transitivo para 7.6.5 e corrige GHSA-j3f2-48v5-ccww / CVE-2026-59877 sem alterar APIs ou prompts. |
 | `v02.23.04` | Restaura fragmentos interpretativos completos, extensão sem teto artificial e iconografia obrigatória, mantendo apenas a exclusão de metodologia e o fix do 422.     |

--- a/astrologo-frontend/functions/api/_shared/modelAvailability.test.ts
+++ b/astrologo-frontend/functions/api/_shared/modelAvailability.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import { estimateTokensWithModelFallback } from './modelAvailability';
+import type { VertexGenAI } from './vertex';
+import { VertexHttpError } from './vertex';
+import { DEFAULT_VERTEX_ANALYSIS_MODEL, resolveVertexAnalysisModel } from './vertexModelCapabilities';
+
+const aiWith = (countTokens: (args: { model: string }) => Promise<{ totalTokens?: number }>): VertexGenAI =>
+  ({ models: { countTokens } }) as unknown as VertexGenAI;
+
+describe('estimateTokensWithModelFallback — fallback só em indisponibilidade real', () => {
+  it('mantém o modelo do seletor quando a contagem funciona', async () => {
+    const profile = resolveVertexAnalysisModel('gemini-9.9-ultra');
+    const ai = aiWith(async () => ({ totalTokens: 1234 }));
+    const log = vi.fn();
+
+    const result = await estimateTokensWithModelFallback(ai, 'prompt', profile, log);
+
+    expect(result.profile.model).toBe('gemini-9.9-ultra');
+    expect(result.tokenCount).toBe(1234);
+  });
+
+  it('cai para o padrão validado quando o publisher model responde 404, re-contando com o padrão', async () => {
+    const profile = resolveVertexAnalysisModel('gemini-9.9-ultra');
+    const chamadas: string[] = [];
+    const ai = aiWith(async ({ model }) => {
+      chamadas.push(model);
+      if (model === 'gemini-9.9-ultra') {
+        throw new VertexHttpError(
+          'Vertex countTokens falhou (HTTP 404): Publisher Model not found',
+          404,
+          'countTokens',
+        );
+      }
+      return { totalTokens: 777 };
+    });
+    const log = vi.fn();
+
+    const result = await estimateTokensWithModelFallback(ai, 'prompt', profile, log);
+
+    expect(chamadas).toEqual(['gemini-9.9-ultra', DEFAULT_VERTEX_ANALYSIS_MODEL]);
+    expect(result.profile.model).toBe(DEFAULT_VERTEX_ANALYSIS_MODEL);
+    expect(result.tokenCount).toBe(777);
+  });
+
+  it('um 404 da mint OAuth NÃO troca o modelo (proveniência da operação)', async () => {
+    const profile = resolveVertexAnalysisModel('gemini-9.9-ultra');
+    const ai = aiWith(async () => {
+      throw new VertexHttpError('Falha ao obter access token OAuth (HTTP 404)', 404, 'oauth-token');
+    });
+
+    const result = await estimateTokensWithModelFallback(ai, 'prompt', profile, vi.fn());
+
+    expect(result.profile.model).toBe('gemini-9.9-ultra');
+    expect(result.tokenCount).toBe(-1);
+  });
+
+  it('não entra em loop quando o próprio padrão está indisponível', async () => {
+    const profile = resolveVertexAnalysisModel(DEFAULT_VERTEX_ANALYSIS_MODEL);
+    let chamadas = 0;
+    const ai = aiWith(async () => {
+      chamadas += 1;
+      throw new VertexHttpError('Vertex countTokens falhou (HTTP 404): not found', 404, 'countTokens');
+    });
+
+    const result = await estimateTokensWithModelFallback(ai, 'prompt', profile, vi.fn());
+
+    expect(chamadas).toBe(1);
+    expect(result.profile.model).toBe(DEFAULT_VERTEX_ANALYSIS_MODEL);
+    expect(result.tokenCount).toBe(-1);
+  });
+
+  it('erro transitório (não-404) preserva o modelo e devolve contagem indisponível', async () => {
+    const profile = resolveVertexAnalysisModel('gemini-3.6-flash');
+    const ai = aiWith(async () => {
+      throw new VertexHttpError('Vertex countTokens falhou (HTTP 500): internal', 500, 'countTokens');
+    });
+
+    const result = await estimateTokensWithModelFallback(ai, 'prompt', profile, vi.fn());
+
+    expect(result.profile.model).toBe('gemini-3.6-flash');
+    expect(result.tokenCount).toBe(-1);
+  });
+});

--- a/astrologo-frontend/functions/api/_shared/modelAvailability.ts
+++ b/astrologo-frontend/functions/api/_shared/modelAvailability.ts
@@ -1,0 +1,58 @@
+// Módulo: functions/api/_shared/modelAvailability.ts
+// Fallback de runtime do seletor de modelos (diretiva fleet-wide 2026-08-09):
+// o modelo configurado roda primeiro; só quando o Vertex o declara
+// indisponível (404 de publisher model — nunca falha da mint OAuth) o perfil
+// cai para o padrão validado, ANTES de qualquer plano de análise ser
+// persistido. A troca acontece uma única vez por requisição (após o fallback,
+// o perfil é o padrão) e nunca no meio de um job particionado.
+
+import { isVertexModelUnavailableError, type VertexGenAI } from './vertex';
+import {
+  DEFAULT_VERTEX_ANALYSIS_MODEL,
+  resolveVertexAnalysisModel,
+  type VertexAnalysisModelProfile,
+} from './vertexModelCapabilities';
+
+export interface ModelAwareTokenEstimate {
+  readonly profile: VertexAnalysisModelProfile;
+  readonly tokenCount: number;
+}
+
+type StructuredLogFn = (level: 'WARN', message: string, context?: Record<string, unknown>) => void;
+
+/**
+ * Conta os tokens do prompt com o modelo do perfil selecionado. Um 404 de
+ * publisher model rebaixa o perfil para o padrão validado e re-conta; qualquer
+ * outro erro preserva o perfil e devolve contagem indisponível (-1), mantendo
+ * a semântica tolerante do planejamento (heurística de bytes).
+ */
+export const estimateTokensWithModelFallback = async (
+  ai: VertexGenAI,
+  prompt: string,
+  profile: VertexAnalysisModelProfile,
+  log: StructuredLogFn,
+): Promise<ModelAwareTokenEstimate> => {
+  try {
+    const resp = await ai.models.countTokens({
+      model: profile.model,
+      contents: prompt,
+      config: { httpOptions: { timeout: 20_000 } },
+    });
+    return { profile, tokenCount: resp.totalTokens ?? -1 };
+  } catch (err) {
+    if (isVertexModelUnavailableError(err) && profile.model !== DEFAULT_VERTEX_ANALYSIS_MODEL) {
+      log('WARN', 'Modelo do seletor indisponível no Vertex — fallback para o padrão validado', {
+        selected_model: profile.model,
+        fallback_model: DEFAULT_VERTEX_ANALYSIS_MODEL,
+      });
+      return estimateTokensWithModelFallback(
+        ai,
+        prompt,
+        resolveVertexAnalysisModel(DEFAULT_VERTEX_ANALYSIS_MODEL),
+        log,
+      );
+    }
+    log('WARN', 'Erro ao contar tokens', { error: String(err) });
+    return { profile, tokenCount: -1 };
+  }
+};

--- a/astrologo-frontend/functions/api/_shared/vertex.test.ts
+++ b/astrologo-frontend/functions/api/_shared/vertex.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { VertexGenAI, VertexHttpError } from './vertex';
+import { isVertexModelUnavailableError, VertexGenAI, VertexHttpError } from './vertex';
 
 const te = new TextEncoder();
 
@@ -397,5 +397,66 @@ describe('regressão workerd e erros diagnósticos', () => {
       fetchImpl: mock.fetchImpl,
     });
     await expect(partial.models.countTokens({ model: 'm', contents: 'x' })).rejects.toThrow(/private_key/u);
+  });
+});
+
+describe('proveniência de operação nos erros (fallback de seletor)', () => {
+  it('VertexHttpError carrega a operação de origem — generateContent, countTokens e oauth-token são distinguíveis', async () => {
+    const saGen = await makeTestSa('kid-op-gen');
+    const gen404 = makeFetchMock({
+      apiStatus: 404,
+      apiPayload: { error: { code: 404, message: 'Publisher Model not found' } },
+    });
+    const genFailure = await client(saGen, gen404)
+      .models.generateContent({ model: 'm', contents: 'x' })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+    expect((genFailure as VertexHttpError).operation).toBe('generateContent');
+    expect(isVertexModelUnavailableError(genFailure)).toBe(true);
+
+    const saCount = await makeTestSa('kid-op-count');
+    const count404 = makeFetchMock({
+      apiStatus: 404,
+      apiPayload: { error: { code: 404, message: 'Publisher Model not found' } },
+    });
+    const countFailure = await client(saCount, count404)
+      .models.countTokens({ model: 'm', contents: 'x' })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+    expect((countFailure as VertexHttpError).operation).toBe('countTokens');
+    expect(isVertexModelUnavailableError(countFailure)).toBe(true);
+  });
+
+  it('falha da mint OAuth carrega oauth-token e NUNCA conta como modelo indisponível', async () => {
+    const sa = await makeTestSa('kid-op-oauth');
+    const mock = makeFetchMock({
+      tokenStatus: 404,
+      tokenPayload: { error: 'not_found' },
+    });
+    const failure = await client(sa, mock)
+      .models.countTokens({ model: 'm', contents: 'x' })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+    expect(failure).toBeInstanceOf(VertexHttpError);
+    expect((failure as VertexHttpError).operation).toBe('oauth-token');
+    expect(isVertexModelUnavailableError(failure)).toBe(false);
+  });
+
+  it('404 é indisponibilidade só com status 404: outros status não disparam o predicado', async () => {
+    const sa = await makeTestSa('kid-op-429');
+    const mock = makeFetchMock({ apiStatus: 429, apiPayload: { error: { code: 429, message: 'rate' } } });
+    const failure = await client(sa, mock)
+      .models.generateContent({ model: 'm', contents: 'x' })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+    expect(isVertexModelUnavailableError(failure)).toBe(false);
   });
 });

--- a/astrologo-frontend/functions/api/_shared/vertex.ts
+++ b/astrologo-frontend/functions/api/_shared/vertex.ts
@@ -72,17 +72,27 @@ export interface VertexGenerateContentResponse {
   text: string;
 }
 
-/** Erro HTTP com status numérico preservado para o classificador de retry do caller. */
+/** Operação de origem de um VertexHttpError — permite ao caller distinguir um
+ * 404 de publisher model (fallback de seletor) de falhas da mint OAuth. */
+export type VertexOperation = 'oauth-token' | 'generateContent' | 'countTokens';
+
+/** Erro HTTP com status numérico e operação de origem preservados para o classificador de retry/fallback do caller. */
 export class VertexHttpError extends Error {
   override readonly name = 'VertexHttpError';
 
   constructor(
     message: string,
     readonly status: number,
+    readonly operation: VertexOperation,
   ) {
     super(message);
   }
 }
+
+/** Um 404 de publisher model (countTokens/generateContent) significa modelo
+ * indisponível; um 404 da mint OAuth ou de qualquer outra origem não. */
+export const isVertexModelUnavailableError = (error: unknown): boolean =>
+  error instanceof VertexHttpError && error.status === 404 && error.operation !== 'oauth-token';
 
 const OAUTH_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
 const OAUTH_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer';
@@ -221,6 +231,7 @@ const mintAccessToken = async (
     throw new VertexHttpError(
       `Falha ao obter access token OAuth para ${sa.client_email} (HTTP ${res.status}): ${detail}`,
       res.status,
+      'oauth-token',
     );
   }
   const data = (await res.json()) as { access_token?: string; expires_in?: number };
@@ -327,7 +338,7 @@ export class VertexGenAI {
 
   private async request(
     model: string,
-    verb: string,
+    verb: 'generateContent' | 'countTokens',
     body: Record<string, unknown>,
     timeoutMs?: number,
   ): Promise<unknown> {
@@ -345,7 +356,7 @@ export class VertexGenAI {
     });
     if (!res.ok) {
       const detail = (await res.text()).slice(0, ERROR_BODY_EXCERPT);
-      throw new VertexHttpError(`Vertex ${verb} falhou (HTTP ${res.status}): ${detail}`, res.status);
+      throw new VertexHttpError(`Vertex ${verb} falhou (HTTP ${res.status}): ${detail}`, res.status, verb);
     }
     return res.json();
   }

--- a/astrologo-frontend/functions/api/_shared/vertexModelCapabilities.test.ts
+++ b/astrologo-frontend/functions/api/_shared/vertexModelCapabilities.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_VERTEX_ANALYSIS_MODEL, resolveVertexAnalysisModel } from './vertexModelCapabilities';
+
+describe('resolveVertexAnalysisModel — seletor sempre respeitado', () => {
+  it('aceita gemini-3.6-flash com os limites validados empiricamente', () => {
+    const profile = resolveVertexAnalysisModel('gemini-3.6-flash');
+    expect(profile.model).toBe('gemini-3.6-flash');
+    expect(profile.outputTokenLimit).toBe(65_536);
+    expect(profile.inputTokenLimit).toBe(128_000);
+  });
+
+  it('respeita ID desconhecido-mas-válido como está, com limites conservadores (nunca rebaixa na seleção)', () => {
+    const profile = resolveVertexAnalysisModel('gemini-9.9-ultra');
+    expect(profile.model).toBe('gemini-9.9-ultra');
+    expect(profile.outputTokenLimit).toBe(65_535);
+    expect(profile.inputTokenLimit).toBe(128_000);
+  });
+
+  it('cai no padrão apenas para valores ausentes ou sintaticamente inválidos para o path da URL', () => {
+    for (const invalido of [
+      null,
+      undefined,
+      '',
+      '   ',
+      'models/gemini-3.1-pro-preview',
+      'gemini 2.5 pro',
+      '../x',
+      '-gemini',
+    ]) {
+      expect(resolveVertexAnalysisModel(invalido as string | null | undefined).model).toBe(
+        DEFAULT_VERTEX_ANALYSIS_MODEL,
+      );
+    }
+  });
+
+  it('mantém os limites exatos da tabela validada para os nove modelos conhecidos', () => {
+    const esperados: Record<string, number> = {
+      'gemini-3.6-flash': 65_536,
+      'gemini-3.5-flash': 65_536,
+      'gemini-3.5-flash-lite': 65_536,
+      'gemini-3.1-pro-preview': 65_536,
+      'gemini-3.1-flash-lite': 65_536,
+      'gemini-3-flash-preview': 65_536,
+      'gemini-2.5-pro': 65_536,
+      'gemini-2.5-flash': 65_536,
+      'gemini-2.5-flash-lite': 65_535,
+    };
+    for (const [modelo, output] of Object.entries(esperados)) {
+      const profile = resolveVertexAnalysisModel(modelo);
+      expect(profile.model).toBe(modelo);
+      expect(profile.outputTokenLimit).toBe(output);
+    }
+  });
+});

--- a/astrologo-frontend/functions/api/_shared/vertexModelCapabilities.ts
+++ b/astrologo-frontend/functions/api/_shared/vertexModelCapabilities.ts
@@ -8,10 +8,16 @@ export const DEFAULT_VERTEX_ANALYSIS_MODEL = 'gemini-3.1-pro-preview';
 
 const ORCHESTRATION_INPUT_TOKEN_LIMIT = 128_000;
 
-// Somente publisher models de texto que as fichas oficiais declaram compatíveis
-// com Count Tokens e Structured Output. Uma nova opção do Admin só entra aqui
-// depois que seus limites e esses dois contratos forem verificados no Vertex.
+// Tabela de CAPACIDADES validadas empiricamente no Vertex (limites reais por
+// modelo). Diretiva do operador (2026-08-09, fleet-wide): o seletor é SEMPRE
+// respeitado — esta tabela NÃO gateia a seleção. Um ID configurado que não
+// esteja aqui é usado exatamente como está, com limites conservadores; a
+// queda para o padrão acontece apenas (a) na seleção, quando o valor é
+// ausente/sintaticamente inválido para o path da URL do publisher model, ou
+// (b) em runtime, quando o Vertex responde 404 para o modelo selecionado
+// (ver modelAvailability.ts).
 const VERTEX_ANALYSIS_MODEL_CAPABILITIES = Object.freeze({
+  'gemini-3.6-flash': { inputTokenLimit: 1_048_576, outputTokenLimit: 65_536 },
   'gemini-3.5-flash': { inputTokenLimit: 1_048_576, outputTokenLimit: 65_536 },
   'gemini-3.5-flash-lite': { inputTokenLimit: 1_048_576, outputTokenLimit: 65_536 },
   'gemini-3.1-pro-preview': { inputTokenLimit: 1_048_576, outputTokenLimit: 65_536 },
@@ -22,6 +28,19 @@ const VERTEX_ANALYSIS_MODEL_CAPABILITIES = Object.freeze({
   'gemini-2.5-flash-lite': { inputTokenLimit: 1_048_576, outputTokenLimit: 65_535 },
 } satisfies Record<string, Omit<VertexAnalysisModelProfile, 'model'>>);
 
+// Limites conservadores para IDs fora da tabela: entrada limitada pelo teto de
+// orquestração (vale para todos os publisher models conhecidos) e saída no
+// menor teto observado entre os modelos validados — nunca provoca 400 por
+// maxOutputTokens acima do suportado.
+const CONSERVATIVE_UNKNOWN_MODEL_CAPABILITIES = Object.freeze({
+  inputTokenLimit: 1_048_576,
+  outputTokenLimit: 65_535,
+});
+
+// O ID compõe o path da URL do Vertex (…/publishers/google/models/<id>:verbo);
+// aceita apenas o formato de publisher model, sem separadores de path/espaços.
+const VALID_MODEL_ID = /^[a-z0-9](?:[a-z0-9.-]{0,126}[a-z0-9])?$/i;
+
 type SupportedVertexAnalysisModel = keyof typeof VERTEX_ANALYSIS_MODEL_CAPABILITIES;
 
 const isSupportedVertexAnalysisModel = (model: string): model is SupportedVertexAnalysisModel =>
@@ -29,8 +48,10 @@ const isSupportedVertexAnalysisModel = (model: string): model is SupportedVertex
 
 export const resolveVertexAnalysisModel = (configuredModel: string | null | undefined): VertexAnalysisModelProfile => {
   const candidate = configuredModel?.trim() ?? '';
-  const model = isSupportedVertexAnalysisModel(candidate) ? candidate : DEFAULT_VERTEX_ANALYSIS_MODEL;
-  const capabilities = VERTEX_ANALYSIS_MODEL_CAPABILITIES[model];
+  const model = VALID_MODEL_ID.test(candidate) ? candidate : DEFAULT_VERTEX_ANALYSIS_MODEL;
+  const capabilities = isSupportedVertexAnalysisModel(model)
+    ? VERTEX_ANALYSIS_MODEL_CAPABILITIES[model]
+    : CONSERVATIVE_UNKNOWN_MODEL_CAPABILITIES;
 
   return Object.freeze({
     model,

--- a/astrologo-frontend/functions/api/analisar.partitioned.test.ts
+++ b/astrologo-frontend/functions/api/analisar.partitioned.test.ts
@@ -7,6 +7,7 @@ const runtime = vi.hoisted(() => ({
   generateErrors: [] as Array<Error & { status?: number }>,
   finishReasons: ['STOP'] as string[],
   totalTokens: 100,
+  count404Models: [] as string[],
   model: 'gemini-3.1-pro-preview',
   fragmentHtml: '<h2>Parte validada</h2><p>Análise fragmentada em português do Brasil.</p>',
   synthesisHtml: '',
@@ -19,52 +20,76 @@ const runtime = vi.hoisted(() => ({
   completedAnalysisHtml: null as string | null,
 }));
 
-vi.mock('./_shared/vertex', () => ({
-  VertexGenAI: class {
-    readonly models = {
-      countTokens: async () => ({ totalTokens: runtime.totalTokens }),
-      generateContent: async (request: Record<string, unknown>) => {
-        runtime.generateCalls += 1;
-        runtime.generateRequests.push(request);
-        const generateError = runtime.generateErrors.shift();
-        if (generateError) throw generateError;
-        const config = request.config as
-          | {
-              responseJsonSchema?: {
-                properties?: {
-                  html?: unknown;
-                  synthesisNotes?: {
-                    items?: { properties?: { evidenceIds?: { items?: { enum?: string[] } } } };
+vi.mock('./_shared/vertex', () => {
+  class MockVertexHttpError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+      readonly operation: string,
+    ) {
+      super(message);
+      this.name = 'VertexHttpError';
+    }
+  }
+  return {
+    VertexHttpError: MockVertexHttpError,
+    isVertexModelUnavailableError: (error: unknown): boolean =>
+      error instanceof MockVertexHttpError && error.status === 404 && error.operation !== 'oauth-token',
+    VertexGenAI: class {
+      readonly models = {
+        countTokens: async (request: Record<string, unknown>) => {
+          if (runtime.count404Models.includes(request.model as string)) {
+            throw new MockVertexHttpError(
+              `Vertex countTokens falhou (HTTP 404): Publisher Model \`${request.model}\` not found.`,
+              404,
+              'countTokens',
+            );
+          }
+          return { totalTokens: runtime.totalTokens };
+        },
+        generateContent: async (request: Record<string, unknown>) => {
+          runtime.generateCalls += 1;
+          runtime.generateRequests.push(request);
+          const generateError = runtime.generateErrors.shift();
+          if (generateError) throw generateError;
+          const config = request.config as
+            | {
+                responseJsonSchema?: {
+                  properties?: {
+                    html?: unknown;
+                    synthesisNotes?: {
+                      items?: { properties?: { evidenceIds?: { items?: { enum?: string[] } } } };
+                    };
                   };
                 };
-              };
-            }
-          | undefined;
-        const responseSchema = config?.responseJsonSchema;
-        const evidenceIds = responseSchema?.properties?.synthesisNotes?.items?.properties?.evidenceIds?.items?.enum;
-        const structuredText = responseSchema
-          ? responseSchema.properties?.synthesisNotes
-            ? JSON.stringify({
-                ...(responseSchema.properties.html ? { html: runtime.fragmentHtml } : {}),
-                synthesisNotes: [
-                  {
-                    textPtBr: 'Síntese factual da parte validada.',
-                    evidenceIds,
-                  },
-                ],
-                warnings: [],
-              })
-            : JSON.stringify({ html: runtime.synthesisHtml, warnings: [] })
-          : runtime.directHtml;
-        return {
-          text: structuredText,
-          candidates: [{ finishReason: runtime.finishReasons.shift() ?? 'STOP' }],
-          usageMetadata: { promptTokenCount: 1_000, candidatesTokenCount: 100, thoughtsTokenCount: 50 },
-        };
-      },
-    };
-  },
-}));
+              }
+            | undefined;
+          const responseSchema = config?.responseJsonSchema;
+          const evidenceIds = responseSchema?.properties?.synthesisNotes?.items?.properties?.evidenceIds?.items?.enum;
+          const structuredText = responseSchema
+            ? responseSchema.properties?.synthesisNotes
+              ? JSON.stringify({
+                  ...(responseSchema.properties.html ? { html: runtime.fragmentHtml } : {}),
+                  synthesisNotes: [
+                    {
+                      textPtBr: 'Síntese factual da parte validada.',
+                      evidenceIds,
+                    },
+                  ],
+                  warnings: [],
+                })
+              : JSON.stringify({ html: runtime.synthesisHtml, warnings: [] })
+            : runtime.directHtml;
+          return {
+            text: structuredText,
+            candidates: [{ finishReason: runtime.finishReasons.shift() ?? 'STOP' }],
+            usageMetadata: { promptTokenCount: 1_000, candidatesTokenCount: 100, thoughtsTokenCount: 50 },
+          };
+        },
+      };
+    },
+  };
+});
 
 vi.mock('./_shared/advancedAnalysisPrompt', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./_shared/advancedAnalysisPrompt')>();
@@ -354,6 +379,7 @@ beforeEach(() => {
   runtime.generateErrors = [];
   runtime.finishReasons = ['STOP'];
   runtime.totalTokens = 100;
+  runtime.count404Models = [];
   runtime.model = 'gemini-3.1-pro-preview';
   runtime.fragmentHtml = '<h2>Parte validada</h2><p>Análise fragmentada em português do Brasil.</p>';
   runtime.directHtml =
@@ -388,8 +414,22 @@ describe('/api/analisar — protocolo reentrante', () => {
     });
   });
 
-  it('substitui o alias legado por um publisher model Vertex compatível', async () => {
+  it('respeita o seletor mesmo para IDs fora da tabela validada, com limites conservadores (nunca rebaixa na seleção)', async () => {
     runtime.model = 'gemini-pro-latest';
+
+    await onRequestPost(context({ action: 'start', id: MAP_ID }));
+    await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+
+    expect(JSON.parse(String(runtime.job?.plan_json))).toMatchObject({
+      model: 'gemini-pro-latest',
+      modelInputTokenLimit: 128_000,
+      modelOutputTokenLimit: 65_535,
+    });
+  });
+
+  it('cai para o padrão validado ANTES de persistir o plano quando o Vertex responde 404 para o modelo do seletor', async () => {
+    runtime.model = 'gemini-9.9-ultra';
+    runtime.count404Models = ['gemini-9.9-ultra'];
 
     await onRequestPost(context({ action: 'start', id: MAP_ID }));
     await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
@@ -401,7 +441,7 @@ describe('/api/analisar — protocolo reentrante', () => {
     });
   });
 
-  it('normaliza modelo e teto de saída ao retomar um plano persistido pela versão anterior', async () => {
+  it('clampa limites herdados ao retomar plano persistido, preservando o modelo do seletor', async () => {
     await onRequestPost(context({ action: 'start', id: MAP_ID }));
     await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
     if (!runtime.job || !runtime.steps[0]) throw new Error('plano de teste ausente');
@@ -425,18 +465,21 @@ describe('/api/analisar — protocolo reentrante', () => {
 
     expect(completed.status).toBe(200);
     expect(runtime.generateRequests[0]).toMatchObject({
-      model: 'gemini-3.1-pro-preview',
-      config: { maxOutputTokens: 65_536 },
+      model: 'gemini-pro-latest',
+      config: { maxOutputTokens: 65_535 },
     });
   });
 
-  it('recusa variantes Vertex sem os contratos de texto estruturado da análise', async () => {
+  it('respeita variantes desconhecidas na seleção (indisponibilidade real é tratada pelo fallback 404, não por lista)', async () => {
     runtime.model = 'gemini-3.1-flash-lite-image';
 
     await onRequestPost(context({ action: 'start', id: MAP_ID }));
     await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
 
-    expect(JSON.parse(String(runtime.job?.plan_json))).toMatchObject({ model: 'gemini-3.1-pro-preview' });
+    expect(JSON.parse(String(runtime.job?.plan_json))).toMatchObject({
+      model: 'gemini-3.1-flash-lite-image',
+      modelOutputTokenLimit: 65_535,
+    });
   });
 
   it('limita a escalada de saída à capacidade oficial do publisher model selecionado', async () => {

--- a/astrologo-frontend/functions/api/analisar.ts
+++ b/astrologo-frontend/functions/api/analisar.ts
@@ -64,6 +64,7 @@ import {
   restoreMonolithicPromptPayloads,
   sha256Text,
 } from './_shared/longAnalysisPlanner';
+import { estimateTokensWithModelFallback } from './_shared/modelAvailability';
 import { loadConfiguredAstrologerModel } from './_shared/modelConfig';
 import {
   type D1DatabaseLike,
@@ -721,24 +722,6 @@ const analysisSourceEvidenceIds = (options: {
   ...(options.locality ? ['advanced.locality'] : []),
 ];
 
-/**
- * Conta tokens da requisição usando o cliente Vertex
- * Permite validação pré-envio e otimização de custos
- */
-const estimateTokenCount = async (ai: VertexGenAI, prompt: string, model: string): Promise<number> => {
-  try {
-    const resp = await ai.models.countTokens({
-      model,
-      contents: prompt,
-      config: { httpOptions: { timeout: 20_000 } },
-    });
-    return resp.totalTokens ?? -1;
-  } catch (err) {
-    structuredLog('WARN', 'Erro ao contar tokens', { error: String(err) });
-    return -1;
-  }
-};
-
 // Every tokenizer token consumes at least one UTF-8 byte. Treating the byte
 // length as a token count is deliberately conservative and keeps planning
 // local, deterministic and bounded to the current HTTP request.
@@ -981,13 +964,23 @@ export async function legacySynchronousAnalysisRequest(context: Context) {
     });
 
     // ==== DYNAMIC MODEL CONFIGURATION VIA BIGDATA_DB ====
-    const selectedModelProfile = resolveVertexAnalysisModel(
+    // Seletor sempre respeitado: o ID configurado é usado como está; a queda
+    // para o padrão validado só acontece se o Vertex responder 404 para ele
+    // (estimateTokensWithModelFallback), antes de qualquer plano persistir.
+    const configuredModelProfile = resolveVertexAnalysisModel(
       await loadConfiguredAstrologerModel(env.BIGDATA_DB, DEFAULT_VERTEX_ANALYSIS_MODEL),
     );
-    const selectedModel = selectedModelProfile.model;
 
     // Inicializa o cliente Vertex (service account OAuth, ver _shared/vertex.ts)
     const ai = await createGeminiClient(env);
+
+    const { profile: selectedModelProfile, tokenCount } = await estimateTokensWithModelFallback(
+      ai,
+      prompt,
+      configuredModelProfile,
+      structuredLog,
+    );
+    const selectedModel = selectedModelProfile.model;
 
     // ==== PASSO 1: limites reais do modelo e planejamento por volume ====
     structuredLog('INFO', 'Iniciando análise astrológica via Vertex AI REST', {
@@ -996,7 +989,6 @@ export async function legacySynchronousAnalysisRequest(context: Context) {
     });
 
     const modelLimits = selectedModelProfile;
-    const tokenCount = await estimateTokenCount(ai, prompt, selectedModel);
     const directTokenCeiling = Math.min(
       LONG_ANALYSIS_DIRECT_TOKEN_CEILING,
       Math.floor(modelLimits.inputTokenLimit * 0.75),
@@ -1650,13 +1642,20 @@ const planReentrantAnalysis = async (env: EnvBindings, job: AnalysisJobRecord, l
     locality: canonicalLocality,
   });
 
-  const selectedModelProfile = resolveVertexAnalysisModel(
+  // Seletor sempre respeitado: ID configurado usado como está; fallback para o
+  // padrão validado só em 404 do publisher model, antes de persistir o plano.
+  const configuredModelProfile = resolveVertexAnalysisModel(
     await loadConfiguredAstrologerModel(env.BIGDATA_DB, DEFAULT_VERTEX_ANALYSIS_MODEL),
   );
-  const model = selectedModelProfile.model;
   const ai = await createGeminiClient(env);
+  const { profile: selectedModelProfile, tokenCount } = await estimateTokensWithModelFallback(
+    ai,
+    prompt,
+    configuredModelProfile,
+    structuredLog,
+  );
+  const model = selectedModelProfile.model;
   const modelLimits = selectedModelProfile;
-  const tokenCount = await estimateTokenCount(ai, prompt, model);
   const directTokenCeiling = Math.min(
     LONG_ANALYSIS_DIRECT_TOKEN_CEILING,
     Math.floor(modelLimits.inputTokenLimit * 0.75),

--- a/astrologo-frontend/package.json
+++ b/astrologo-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astrologo-frontend",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "Astrólogo — gerador de mapas astrais e análises esotéricas via integração Gemini AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.",
   "license": "AGPL-3.0-or-later",
   "author": "LCV Ideas & Software",

--- a/astrologo-frontend/src/App.tsx
+++ b/astrologo-frontend/src/App.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 // Módulo: astrologo-frontend/src/App.tsx
-// Versão: v02.24.00
+// Versão: v02.25.00
 // Descrição: Frontend principal do Oráculo Celestial com análise astrológica via Gemini.
 
 import DOMPurify from 'dompurify';
@@ -73,7 +73,7 @@ import { isSynastryRunV1, renderSynastryRunEmailHtml, renderSynastryRunText } fr
 import { formatTatwaDurationPtBr, presentTatwa } from './tatwaPresentation';
 import { isTransitRunV1, renderTransitRunEmailHtml, renderTransitRunText, type TransitRunV1 } from './transitRunV1';
 
-const APP_VERSION = 'APP v02.24.00';
+const APP_VERSION = 'APP v02.25.00';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const isValidEmail = (value: string): boolean => emailRegex.test(value.trim());


### PR DESCRIPTION
## Diretiva fleet-wide: o seletor de modelos é sempre respeitado

Diretiva do operador (2026-08-09): o valor configurado no seletor do admin deve ser usado exatamente como está; a tabela validada atua como **fallback**, aplicado apenas quando o modelo selecionado está indisponível. O contrato anterior (allowlist fail-closed na seleção) rebaixaria silenciosamente `gemini-3.6-flash` — o flash mais novo, já validado e em uso na frota.

### O que muda
- **`vertexModelCapabilities.ts`**: a tabela deixa de gatear a seleção. ID sintaticamente válido é usado como configurado; IDs fora da tabela recebem limites conservadores (entrada 128k pela orquestração; saída 65.535, menor teto observado). `gemini-3.6-flash` entra na tabela validada (saída 65.536, validado empiricamente no endpoint global em 2026-08-09: countTokens/generateContent 200; teto declarado pela API via sonda fora-de-faixa).
- **`modelAvailability.ts` (novo)**: o fallback para `gemini-3.1-pro-preview` ocorre somente em runtime, quando o Vertex responde **404 de publisher model** na contagem inicial de tokens — antes de qualquer plano de análise ser persistido e nunca no meio de um job particionado (coerência entre fragmentos).
- **`vertex.ts`**: `VertexHttpError` carrega a operação de origem (`oauth-token` | `generateContent` | `countTokens`) — um 404 da mint OAuth nunca dispara a troca de modelo (predicado `isVertexModelUnavailableError`).
- **Retomada de jobs**: planos persistidos continuam clampados aos limites atuais, agora preservando o modelo do seletor em vez de reescrevê-lo.
- Bump v02.25.00 nas 6 superfícies (package.json, App.tsx ×2, READMEs ×2, SECURITY.md) + CHANGELOG.

### Verificação
- TDD contínuo: cada comportamento novo teve RED observado antes do GREEN (capacidades, disponibilidade/fallback, proveniência de operação, contratos dos jobs particionados); os testes do contrato antigo de gate foram reescritos para o contrato da diretiva.
- Gates locais com exit codes reais: vitest 338/338 ✓ · biome ✓ · eslint ✓ · `tsc -b && vite build` ✓ · `git diff --check` ✓.
- Mesmo desenho já shipado e revisado no oraculo-financeiro v01.11.00 (PR #198).

🤖 Generated with [Claude Code](https://claude.com/claude-code)