### PR TITLE
fix(ai): hardening pós-review — v02.25.01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [v02.25.01] - 2026-08-09
+
+**Correções dos achados dos bots do PR da v02.25.00.**
+
+### Alterado
+
+- Teto conservador de saída para IDs fora da tabela validada reduzido de 65.535 para 8.192 (o request inicial da orquestração): a escalada de `MAX_TOKENS` nunca dobra além do que um modelo desconhecido comprovadamente aceitou, eliminando 400 por `maxOutputTokens` acima do suportado (achado codex P2).
+- `package-lock.json` realinhado à versão do manifesto (achado codex P2 + Copilot).
+- O changelog paralelo do frontend passa a acompanhar as entradas do canônico (achado Copilot).
+
 ## [v02.25.00] - 2026-08-09
 
 **Seletor de modelos sempre respeitado (diretiva fleet-wide do operador).**

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 **Astrólogo** — gerador de mapas astrais e análises esotéricas via integração Gemini AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.
 
-**Status.** Stable. Current release: **v02.25.00**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v02.25.01**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release                              | Scope                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`v02.25.01`**                      | **Hardening pós-review.** Teto conservador de saída para modelos fora da tabela cai para 8.192 (request inicial), lockfile realinhado e changelog paralelo sincronizado.                                                                                                                                                                              |
 | **`v02.25.00`**                      | **Seletor de modelos sempre respeitado.** A tabela de capacidades deixa de gatear a seleção: o ID do seletor do admin é usado como configurado e o fallback para o padrão ocorre apenas quando o Vertex responde 404 para o modelo selecionado; `gemini-3.6-flash` entra na tabela validada.                                                          |
 | **`v02.24.00`**                      | **Transporte Vertex AI.** Migra a autenticação da análise para service account com OAuth2 e usa o cliente REST do Vertex AI, preservando prompts, orquestração, saída estruturada, retries e telemetria.                                                                                                                                            |
 | **`v02.23.05`**                      | **Dependency security patch.** Updates the transitive `protobufjs` override used by `@google/genai` to 7.6.5, resolving GHSA-j3f2-48v5-ccww / CVE-2026-59877 without changing application APIs or prompts. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported status
 
-Latest supported release: v02.25.00. The current main branch is also supported for security fixes until the next release is published.
+Latest supported release: v02.25.01. The current main branch is also supported for security fixes until the next release is published.
 
 ## Reporting a vulnerability
 

--- a/astrologo-frontend/CHANGELOG.md
+++ b/astrologo-frontend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — Astrólogo Frontend
 
+## [v02.25.01] - 2026-08-09
+
+- Teto conservador de saída para IDs fora da tabela validada: 65.535 → 8.192 (request inicial da orquestração), impedindo escalada de `MAX_TOKENS` acima do comprovadamente aceito (achado codex P2). Lockfile realinhado ao manifesto.
+## [v02.25.00] - 2026-08-09
+
+- **Seletor de modelos sempre respeitado (diretiva fleet-wide)**: a tabela de capacidades deixa de gatear a seleção — o ID configurado no seletor do admin é usado exatamente como está (validação apenas sintática); IDs fora da tabela validada recebem limites conservadores (entrada 128 mil tokens pela orquestração; saída 65.535). `gemini-3.6-flash` entra na tabela validada (saída 65.536).
+- Fallback para `gemini-3.1-pro-preview` apenas em runtime, quando o Vertex responde 404 de publisher model para o modelo selecionado, antes de persistir o plano (`modelAvailability.ts`); 404 da mint OAuth nunca troca o modelo (`VertexHttpError` com operação de origem).
 ## [v02.24.00] - 2026-08-08
 
 ### Alterado

--- a/astrologo-frontend/README.md
+++ b/astrologo-frontend/README.md
@@ -19,12 +19,13 @@ Currently, two official plugins are available:
 
 ## Change History
 
-**Status.** Stable. Current release: **v02.25.00**. See [CHANGELOG.md](../CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v02.25.01**. See [CHANGELOG.md](../CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release     | Notes                                                                                                                                                                   |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `v02.25.01` | Teto conservador de saída para modelos fora da tabela: 8.192 (request inicial); lockfile e changelog paralelo realinhados. |
 | `v02.25.00` | O seletor de modelos passa a ser sempre respeitado: sem gate de allowlist na seleção; fallback ao padrão só em indisponibilidade real (404 do publisher model); `gemini-3.6-flash` validado na tabela de capacidades. |
 | `v02.24.00` | Migra a autenticação para service account com OAuth2 e substitui o SDK pelo transporte REST do Vertex AI, preservando a orquestração e os contratos de saída. |
 | `v02.23.05` | Atualiza o `protobufjs` transitivo para 7.6.5 e corrige GHSA-j3f2-48v5-ccww / CVE-2026-59877 sem alterar APIs ou prompts. |

--- a/astrologo-frontend/functions/api/_shared/vertexModelCapabilities.test.ts
+++ b/astrologo-frontend/functions/api/_shared/vertexModelCapabilities.test.ts
@@ -12,7 +12,7 @@ describe('resolveVertexAnalysisModel — seletor sempre respeitado', () => {
   it('respeita ID desconhecido-mas-válido como está, com limites conservadores (nunca rebaixa na seleção)', () => {
     const profile = resolveVertexAnalysisModel('gemini-9.9-ultra');
     expect(profile.model).toBe('gemini-9.9-ultra');
-    expect(profile.outputTokenLimit).toBe(65_535);
+    expect(profile.outputTokenLimit).toBe(8_192);
     expect(profile.inputTokenLimit).toBe(128_000);
   });
 

--- a/astrologo-frontend/functions/api/_shared/vertexModelCapabilities.ts
+++ b/astrologo-frontend/functions/api/_shared/vertexModelCapabilities.ts
@@ -29,12 +29,13 @@ const VERTEX_ANALYSIS_MODEL_CAPABILITIES = Object.freeze({
 } satisfies Record<string, Omit<VertexAnalysisModelProfile, 'model'>>);
 
 // Limites conservadores para IDs fora da tabela: entrada limitada pelo teto de
-// orquestração (vale para todos os publisher models conhecidos) e saída no
-// menor teto observado entre os modelos validados — nunca provoca 400 por
-// maxOutputTokens acima do suportado.
+// orquestração (vale para todos os publisher models conhecidos) e saída
+// travada no tamanho do request inicial da orquestração (8.192) — assim a
+// escalada de MAX_TOKENS nunca dobra além do que o modelo desconhecido
+// comprovadamente aceitou, e nenhum 400 por maxOutputTokens é possível.
 const CONSERVATIVE_UNKNOWN_MODEL_CAPABILITIES = Object.freeze({
   inputTokenLimit: 1_048_576,
-  outputTokenLimit: 65_535,
+  outputTokenLimit: 8_192,
 });
 
 // O ID compõe o path da URL do Vertex (…/publishers/google/models/<id>:verbo);

--- a/astrologo-frontend/functions/api/analisar.partitioned.test.ts
+++ b/astrologo-frontend/functions/api/analisar.partitioned.test.ts
@@ -423,7 +423,7 @@ describe('/api/analisar — protocolo reentrante', () => {
     expect(JSON.parse(String(runtime.job?.plan_json))).toMatchObject({
       model: 'gemini-pro-latest',
       modelInputTokenLimit: 128_000,
-      modelOutputTokenLimit: 65_535,
+      modelOutputTokenLimit: 8_192,
     });
   });
 
@@ -466,7 +466,7 @@ describe('/api/analisar — protocolo reentrante', () => {
     expect(completed.status).toBe(200);
     expect(runtime.generateRequests[0]).toMatchObject({
       model: 'gemini-pro-latest',
-      config: { maxOutputTokens: 65_535 },
+      config: { maxOutputTokens: 8_192 },
     });
   });
 
@@ -478,7 +478,7 @@ describe('/api/analisar — protocolo reentrante', () => {
 
     expect(JSON.parse(String(runtime.job?.plan_json))).toMatchObject({
       model: 'gemini-3.1-flash-lite-image',
-      modelOutputTokenLimit: 65_535,
+      modelOutputTokenLimit: 8_192,
     });
   });
 

--- a/astrologo-frontend/package-lock.json
+++ b/astrologo-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astrologo-frontend",
-  "version": "2.24.0",
+  "version": "2.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astrologo-frontend",
-      "version": "2.24.0",
+      "version": "2.25.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@js-temporal/polyfill": "0.5.1",

--- a/astrologo-frontend/package.json
+++ b/astrologo-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astrologo-frontend",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "description": "Astrólogo — gerador de mapas astrais e análises esotéricas via integração Gemini AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.",
   "license": "AGPL-3.0-or-later",
   "author": "LCV Ideas & Software",

--- a/astrologo-frontend/src/App.tsx
+++ b/astrologo-frontend/src/App.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 // Módulo: astrologo-frontend/src/App.tsx
-// Versão: v02.25.00
+// Versão: v02.25.01
 // Descrição: Frontend principal do Oráculo Celestial com análise astrológica via Gemini.
 
 import DOMPurify from 'dompurify';
@@ -73,7 +73,7 @@ import { isSynastryRunV1, renderSynastryRunEmailHtml, renderSynastryRunText } fr
 import { formatTatwaDurationPtBr, presentTatwa } from './tatwaPresentation';
 import { isTransitRunV1, renderTransitRunEmailHtml, renderTransitRunText, type TransitRunV1 } from './transitRunV1';
 
-const APP_VERSION = 'APP v02.25.00';
+const APP_VERSION = 'APP v02.25.01';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const isValidEmail = (value: string): boolean => emailRegex.test(value.trim());


### PR DESCRIPTION
## Correções dos achados dos bots do PR #262 (v02.25.00)

O automerge do #262 disparou com o CI verde antes da rodada de correções dos bots — este PR entrega os três achados pelo rito completo. **O automerge deste PR será armado somente após a convergência do cross-review** (lição da corrida no #262).

### Mudanças
1. **codex P2 — teto seguro para modelos desconhecidos**: o teto conservador de saída para IDs fora da tabela validada cai de 65.535 para **8.192** (o request inicial da orquestração). A escalada de `MAX_TOKENS` do `executeClaimedStep` nunca dobra além do que o modelo desconhecido comprovadamente aceitou — elimina a possibilidade de 400 por `maxOutputTokens` acima do suportado. TDD: RED observado antes do ajuste.
2. **codex P2 + Copilot — lockfile**: `package-lock.json` realinhado (2.25.1 nos dois campos de versão).
3. **Copilot — changelog paralelo**: `astrologo-frontend/CHANGELOG.md` sincronizado com o canônico (entradas v02.25.00 e v02.25.01); a entrada v02.25.00 preserva o texto efetivamente shipado (honestidade histórica) e as mudanças novas entram como v02.25.01.
4. Bump **v02.25.01** nas 6 superfícies + lockfile.

Sobre o 4º apontamento do Copilot (404 de countTokens ≠ sempre modelo indisponível): disposição fundamentada respondida no thread do #262 — o catálogo do admin só lista modelos com Count Tokens suportado; um 404 na URL do publisher model indica modelo inexistente na location; o custo residual (modelo exótico sem countTokens) rebaixa ao padrão com WARN estruturado, preferível a falhar o job do usuário.

### Verificação
- Gates com exit codes reais: vitest 338/338 ✓ · biome ✓ · eslint ✓ · build ✓ · `git diff --check` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)