### PR TITLE
fix(ai): adaptação de teto em runtime — v02.25.02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [v02.25.02] - 2026-08-09
+
+**Adaptação de teto em runtime (achados codex P1 + Copilot no PR da v02.25.01).**
+
+### Alterado
+
+- O teto conservador de saída para IDs fora da tabela validada volta a ter headroom (65.535): o cap de 8.192 da v02.25.01 eliminava a escalada de `MAX_TOKENS` e criava um beco de truncamento — respostas longas em modelos desconhecidos falhavam o job repetindo o mesmo request (achado codex P1).
+- Novo comportamento no retry de etapa: um 400 de `maxOutputTokens` reduz o valor pela metade (piso 1.024) e mantém a etapa retryable — o teto real do modelo é descoberto em runtime em vez de assumido. A garantia absoluta descrita na v02.25.01 ("nenhum 400 possível") era mais forte que o implementado (achado Copilot); esta versão a substitui por recuperação automática documentada.
+
 ## [v02.25.01] - 2026-08-09
 
 **Correções dos achados dos bots do PR da v02.25.00.**

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 **Astrólogo** — gerador de mapas astrais e análises esotéricas via integração Gemini AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.
 
-**Status.** Stable. Current release: **v02.25.01**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v02.25.02**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release                              | Scope                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`v02.25.02`**                      | **Adaptação de teto em runtime.** Modelos fora da tabela voltam a ter headroom de saída (65.535) e o 400 de `maxOutputTokens` passa a ser auto-recuperado por redução pela metade (piso 1.024) no retry da etapa — o teto real é descoberto, não assumido.                                                                                            |
 | **`v02.25.01`**                      | **Hardening pós-review.** Teto conservador de saída para modelos fora da tabela cai para 8.192 (request inicial), lockfile realinhado e changelog paralelo sincronizado.                                                                                                                                                                              |
 | **`v02.25.00`**                      | **Seletor de modelos sempre respeitado.** A tabela de capacidades deixa de gatear a seleção: o ID do seletor do admin é usado como configurado e o fallback para o padrão ocorre apenas quando o Vertex responde 404 para o modelo selecionado; `gemini-3.6-flash` entra na tabela validada.                                                          |
 | **`v02.24.00`**                      | **Transporte Vertex AI.** Migra a autenticação da análise para service account com OAuth2 e usa o cliente REST do Vertex AI, preservando prompts, orquestração, saída estruturada, retries e telemetria.                                                                                                                                            |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported status
 
-Latest supported release: v02.25.01. The current main branch is also supported for security fixes until the next release is published.
+Latest supported release: v02.25.02. The current main branch is also supported for security fixes until the next release is published.
 
 ## Reporting a vulnerability
 

--- a/astrologo-frontend/CHANGELOG.md
+++ b/astrologo-frontend/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog — Astrólogo Frontend
 
+## [v02.25.02] - 2026-08-09
+
+- Headroom de saída restaurado para modelos fora da tabela (65.535) e auto-recuperação descendente no 400 de `maxOutputTokens` (metade, piso 1.024) no retry da etapa; substitui a garantia absoluta da v02.25.01 por recuperação documentada.
 ## [v02.25.01] - 2026-08-09
 
 - Teto conservador de saída para IDs fora da tabela validada: 65.535 → 8.192 (request inicial da orquestração), impedindo escalada de `MAX_TOKENS` acima do comprovadamente aceito (achado codex P2). Lockfile realinhado ao manifesto.

--- a/astrologo-frontend/README.md
+++ b/astrologo-frontend/README.md
@@ -19,12 +19,13 @@ Currently, two official plugins are available:
 
 ## Change History
 
-**Status.** Stable. Current release: **v02.25.01**. See [CHANGELOG.md](../CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v02.25.02**. See [CHANGELOG.md](../CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release     | Notes                                                                                                                                                                   |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `v02.25.02` | Headroom de saída restaurado para modelos fora da tabela (65.535) com auto-recuperação descendente no 400 de `maxOutputTokens` (metade, piso 1.024) no retry da etapa. |
 | `v02.25.01` | Teto conservador de saída para modelos fora da tabela: 8.192 (request inicial); lockfile e changelog paralelo realinhados. |
 | `v02.25.00` | O seletor de modelos passa a ser sempre respeitado: sem gate de allowlist na seleção; fallback ao padrão só em indisponibilidade real (404 do publisher model); `gemini-3.6-flash` validado na tabela de capacidades. |
 | `v02.24.00` | Migra a autenticação para service account com OAuth2 e substitui o SDK pelo transporte REST do Vertex AI, preservando a orquestração e os contratos de saída. |

--- a/astrologo-frontend/functions/api/_shared/vertexModelCapabilities.test.ts
+++ b/astrologo-frontend/functions/api/_shared/vertexModelCapabilities.test.ts
@@ -12,7 +12,7 @@ describe('resolveVertexAnalysisModel — seletor sempre respeitado', () => {
   it('respeita ID desconhecido-mas-válido como está, com limites conservadores (nunca rebaixa na seleção)', () => {
     const profile = resolveVertexAnalysisModel('gemini-9.9-ultra');
     expect(profile.model).toBe('gemini-9.9-ultra');
-    expect(profile.outputTokenLimit).toBe(8_192);
+    expect(profile.outputTokenLimit).toBe(65_535);
     expect(profile.inputTokenLimit).toBe(128_000);
   });
 

--- a/astrologo-frontend/functions/api/_shared/vertexModelCapabilities.ts
+++ b/astrologo-frontend/functions/api/_shared/vertexModelCapabilities.ts
@@ -28,14 +28,15 @@ const VERTEX_ANALYSIS_MODEL_CAPABILITIES = Object.freeze({
   'gemini-2.5-flash-lite': { inputTokenLimit: 1_048_576, outputTokenLimit: 65_535 },
 } satisfies Record<string, Omit<VertexAnalysisModelProfile, 'model'>>);
 
-// Limites conservadores para IDs fora da tabela: entrada limitada pelo teto de
-// orquestração (vale para todos os publisher models conhecidos) e saída
-// travada no tamanho do request inicial da orquestração (8.192) — assim a
-// escalada de MAX_TOKENS nunca dobra além do que o modelo desconhecido
-// comprovadamente aceitou, e nenhum 400 por maxOutputTokens é possível.
+// Limites para IDs fora da tabela: entrada limitada pelo teto de orquestração
+// e saída com headroom no menor teto observado entre os modelos validados —
+// preserva espaço para a escalada de MAX_TOKENS em respostas longas. Se o teto
+// real do modelo for menor, o 400 de maxOutputTokens é auto-recuperado pela
+// adaptação descendente do retry de etapa (analisar.ts), que reduz o valor
+// pela metade e segue; não há garantia de ausência de 400, e sim recuperação.
 const CONSERVATIVE_UNKNOWN_MODEL_CAPABILITIES = Object.freeze({
   inputTokenLimit: 1_048_576,
-  outputTokenLimit: 8_192,
+  outputTokenLimit: 65_535,
 });
 
 // O ID compõe o path da URL do Vertex (…/publishers/google/models/<id>:verbo);

--- a/astrologo-frontend/functions/api/analisar.partitioned.test.ts
+++ b/astrologo-frontend/functions/api/analisar.partitioned.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { D1DatabaseLike, D1Statement } from './_shared/requestSecurity';
+import { VertexHttpError } from './_shared/vertex';
 
 const runtime = vi.hoisted(() => ({
   generateCalls: 0,
@@ -423,7 +424,7 @@ describe('/api/analisar — protocolo reentrante', () => {
     expect(JSON.parse(String(runtime.job?.plan_json))).toMatchObject({
       model: 'gemini-pro-latest',
       modelInputTokenLimit: 128_000,
-      modelOutputTokenLimit: 8_192,
+      modelOutputTokenLimit: 65_535,
     });
   });
 
@@ -466,7 +467,7 @@ describe('/api/analisar — protocolo reentrante', () => {
     expect(completed.status).toBe(200);
     expect(runtime.generateRequests[0]).toMatchObject({
       model: 'gemini-pro-latest',
-      config: { maxOutputTokens: 8_192 },
+      config: { maxOutputTokens: 65_535 },
     });
   });
 
@@ -478,7 +479,7 @@ describe('/api/analisar — protocolo reentrante', () => {
 
     expect(JSON.parse(String(runtime.job?.plan_json))).toMatchObject({
       model: 'gemini-3.1-flash-lite-image',
-      modelOutputTokenLimit: 8_192,
+      modelOutputTokenLimit: 65_535,
     });
   });
 
@@ -493,6 +494,29 @@ describe('/api/analisar — protocolo reentrante', () => {
       modelInputTokenLimit: 128_000,
       modelOutputTokenLimit: 65_535,
     });
+  });
+
+  it('reduz maxOutputTokens pela metade e continua quando o modelo rejeita o teto com 400 (auto-adaptação descendente)', async () => {
+    runtime.model = 'gemini-9.9-ultra';
+    runtime.generateErrors = [
+      new VertexHttpError(
+        'Vertex generateContent falhou (HTTP 400): GenerateContentRequest.generation_config.max_output_tokens must be in range',
+        400,
+        'generateContent',
+      ) as Error & { status?: number },
+    ];
+
+    await onRequestPost(context({ action: 'start', id: MAP_ID }));
+    await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+
+    const firstAttempt = await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+    expect(firstAttempt.status).toBe(202);
+
+    const secondAttempt = await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+    expect(secondAttempt.status).toBe(200);
+    expect((runtime.generateRequests[1] as { config?: { maxOutputTokens?: number } }).config?.maxOutputTokens).toBe(
+      4_096,
+    );
   });
 
   it('transforma cada tentativa em uma nova requisição e nunca repete dentro do mesmo avanço', async () => {

--- a/astrologo-frontend/functions/api/analisar.ts
+++ b/astrologo-frontend/functions/api/analisar.ts
@@ -75,7 +75,7 @@ import {
   securityHeaders,
 } from './_shared/requestSecurity';
 import { buildAnalysisGlobalsWithCanonicalTatwa, loadCanonicalTatwa } from './_shared/tatwaPrompt';
-import { VertexGenAI } from './_shared/vertex';
+import { VertexGenAI, VertexHttpError } from './_shared/vertex';
 import { DEFAULT_VERTEX_ANALYSIS_MODEL, resolveVertexAnalysisModel } from './_shared/vertexModelCapabilities';
 
 interface EnvBindings {
@@ -1977,12 +1977,25 @@ const executeOneAnalysisStep = async (options: {
     return { kind: payload.kind, completed: true };
   } catch (error) {
     const detail = describeErrorChain(error, error instanceof GeminiStepAttemptError ? error.finishReason : undefined);
+    // Adaptação descendente: se o modelo (tipicamente fora da tabela validada)
+    // rejeitar o teto atual com 400 de maxOutputTokens, reduz pela metade
+    // (piso 1.024) e mantém a etapa retryable — o teto real é descoberto em
+    // runtime em vez de assumido, e a escalada ascendente de MAX_TOKENS
+    // continua disponível para respostas longas.
+    const attemptCause = error instanceof GeminiStepAttemptError ? error.cause : undefined;
+    const outputCapRejected =
+      attemptCause instanceof VertexHttpError &&
+      attemptCause.status === 400 &&
+      /max_?output_?tokens/iu.test(attemptCause.message) &&
+      payload.maxOutputTokens > 1_024;
     const retryPayload =
       error instanceof GeminiStepAttemptError &&
       error.finishReason === 'MAX_TOKENS' &&
       payload.maxOutputTokens < plan.modelOutputTokenLimit
         ? { ...payload, maxOutputTokens: Math.min(plan.modelOutputTokenLimit, payload.maxOutputTokens * 2) }
-        : payload;
+        : outputCapRejected
+          ? { ...payload, maxOutputTokens: Math.max(1_024, Math.floor(payload.maxOutputTokens / 2)) }
+          : payload;
     const retryState = await retryOrFailAnalysisStep({
       db: options.env.BIGDATA_DB,
       jobId: options.job.id,
@@ -1999,6 +2012,7 @@ const executeOneAnalysisStep = async (options: {
       retryable:
         !(error instanceof GeminiStepAttemptError) ||
         error.category === 'validation' ||
+        outputCapRejected ||
         isRetryableTransportError(error.cause),
       inputTokens: usageTotals.inputTokens,
       outputTokens: usageTotals.outputTokens,

--- a/astrologo-frontend/package-lock.json
+++ b/astrologo-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astrologo-frontend",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astrologo-frontend",
-      "version": "2.25.1",
+      "version": "2.25.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@js-temporal/polyfill": "0.5.1",

--- a/astrologo-frontend/package.json
+++ b/astrologo-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astrologo-frontend",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "description": "Astrólogo — gerador de mapas astrais e análises esotéricas via integração Gemini AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.",
   "license": "AGPL-3.0-or-later",
   "author": "LCV Ideas & Software",

--- a/astrologo-frontend/src/App.tsx
+++ b/astrologo-frontend/src/App.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 // Módulo: astrologo-frontend/src/App.tsx
-// Versão: v02.25.01
+// Versão: v02.25.02
 // Descrição: Frontend principal do Oráculo Celestial com análise astrológica via Gemini.
 
 import DOMPurify from 'dompurify';
@@ -73,7 +73,7 @@ import { isSynastryRunV1, renderSynastryRunEmailHtml, renderSynastryRunText } fr
 import { formatTatwaDurationPtBr, presentTatwa } from './tatwaPresentation';
 import { isTransitRunV1, renderTransitRunEmailHtml, renderTransitRunText, type TransitRunV1 } from './transitRunV1';
 
-const APP_VERSION = 'APP v02.25.01';
+const APP_VERSION = 'APP v02.25.02';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const isValidEmail = (value: string): boolean => emailRegex.test(value.trim());


### PR DESCRIPTION
## Correções dos achados do PR #263 (v02.25.01)

Todos os threads do #263 foram respondidos com a ponderação e resolvidos; este PR entrega o redesenho que o **P1 do codex** motivou.

### O problema (codex P1, correto)
O cap de 8.192 da v02.25.01 travava `modelOutputTokenLimit` no tamanho do request inicial: em `MAX_TOKENS`, a escalada virava no-op e o job repetia o request idêntico até falhar — modelos fora da tabela com respostas longas nunca completavam.

### O redesenho (descoberta do teto em runtime)
1. **Headroom restaurado**: IDs fora da tabela validada voltam a ter teto de saída 65.535 — a escalada ascendente de `MAX_TOKENS` funciona para respostas longas.
2. **Auto-recuperação descendente (novo)**: se uma etapa falha com **400 de `maxOutputTokens`** (mensagem do Vertex nomeia o campo), o retry reduz o valor pela metade (piso 1.024) e a etapa permanece retryable — o teto real do modelo é **descoberto**, não assumido. Cobre inclusive a rejeição do request inicial (apontamento do Copilot).
3. **Honestidade documental**: a garantia absoluta da v02.25.01 ("nenhum 400 possível") era mais forte que o implementado (Copilot ×2) — substituída por recuperação documentada em comentário e changelogs; entradas shipadas preservadas.

### Verificação
- TDD: 4 REDs observados (headroom nos 3 contratos + caminho novo de adaptação descendente com sequência 8.192 → 202 → 4.096 → 200).
- Gates com exit codes reais: biome ✓ · eslint ✓ · build ✓ · diff-check ✓; suíte 339 com os 2 flakes conhecidos de timeout WASM/Windows verdes em execução isolada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)