### PR TITLE
fix(ai): negociação de teto fora do orçamento de tentativas — v02.25.03

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [v02.25.03] - 2026-08-09
+
+**Negociação de teto fora do orçamento de tentativas (achados codex P1 + Copilot no PR da v02.25.02).**
+
+### Alterado
+
+- O 400 de `maxOutputTokens` agora registra o teto rejeitado no payload persistido (`outputTokenCeiling`) e a escalada de `MAX_TOKENS` clampa nele — sem oscilação nem re-tentativa de valor já rejeitado (achado Copilot: 8.192↔16.384).
+- A negociação de teto devolve a tentativa consumida (`refundAttempt` no repositório de etapas): a redução até o piso de 1.024 não consome o orçamento de 3 tentativas, que fica reservado para falhas reais (achado codex P1: modelos com teto 1.024 esgotavam o orçamento em 8.192→4.096→2.048 e falhavam antes do piso). O reembolso é finito por construção — o halving é estritamente decrescente.
+
 ## [v02.25.02] - 2026-08-09
 
 **Adaptação de teto em runtime (achados codex P1 + Copilot no PR da v02.25.01).**

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 **Astrólogo** — gerador de mapas astrais e análises esotéricas via integração Gemini AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.
 
-**Status.** Stable. Current release: **v02.25.02**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v02.25.03**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release                              | Scope                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`v02.25.03`**                      | **Negociação de teto fora do orçamento.** O 400 de `maxOutputTokens` registra o teto rejeitado no payload (a escalada clampa nele, sem oscilar) e devolve a tentativa consumida — o piso de 1.024 é sempre alcançável.                                                                                                                               |
 | **`v02.25.02`**                      | **Adaptação de teto em runtime.** Modelos fora da tabela voltam a ter headroom de saída (65.535) e o 400 de `maxOutputTokens` passa a ser auto-recuperado por redução pela metade (piso 1.024) no retry da etapa — o teto real é descoberto, não assumido.                                                                                            |
 | **`v02.25.01`**                      | **Hardening pós-review.** Teto conservador de saída para modelos fora da tabela cai para 8.192 (request inicial), lockfile realinhado e changelog paralelo sincronizado.                                                                                                                                                                              |
 | **`v02.25.00`**                      | **Seletor de modelos sempre respeitado.** A tabela de capacidades deixa de gatear a seleção: o ID do seletor do admin é usado como configurado e o fallback para o padrão ocorre apenas quando o Vertex responde 404 para o modelo selecionado; `gemini-3.6-flash` entra na tabela validada.                                                          |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported status
 
-Latest supported release: v02.25.02. The current main branch is also supported for security fixes until the next release is published.
+Latest supported release: v02.25.03. The current main branch is also supported for security fixes until the next release is published.
 
 ## Reporting a vulnerability
 

--- a/astrologo-frontend/CHANGELOG.md
+++ b/astrologo-frontend/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog — Astrólogo Frontend
 
+## [v02.25.03] - 2026-08-09
+
+- Negociação de teto fora do orçamento: `outputTokenCeiling` persistido no payload clampa a escalada (sem oscilação) e o refund devolve a tentativa da negociação — piso 1.024 sempre alcançável (achados codex P1 + Copilot do PR anterior).
 ## [v02.25.02] - 2026-08-09
 
 - Headroom de saída restaurado para modelos fora da tabela (65.535) e auto-recuperação descendente no 400 de `maxOutputTokens` (metade, piso 1.024) no retry da etapa; substitui a garantia absoluta da v02.25.01 por recuperação documentada.

--- a/astrologo-frontend/README.md
+++ b/astrologo-frontend/README.md
@@ -19,12 +19,13 @@ Currently, two official plugins are available:
 
 ## Change History
 
-**Status.** Stable. Current release: **v02.25.02**. See [CHANGELOG.md](../CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v02.25.03**. See [CHANGELOG.md](../CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release     | Notes                                                                                                                                                                   |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `v02.25.03` | Negociação de teto fora do orçamento de tentativas: teto rejeitado lembrado no payload (escalada clampa nele) e tentativa devolvida no refund — piso 1.024 sempre alcançável. |
 | `v02.25.02` | Headroom de saída restaurado para modelos fora da tabela (65.535) com auto-recuperação descendente no 400 de `maxOutputTokens` (metade, piso 1.024) no retry da etapa. |
 | `v02.25.01` | Teto conservador de saída para modelos fora da tabela: 8.192 (request inicial); lockfile e changelog paralelo realinhados. |
 | `v02.25.00` | O seletor de modelos passa a ser sempre respeitado: sem gate de allowlist na seleção; fallback ao padrão só em indisponibilidade real (404 do publisher model); `gemini-3.6-flash` validado na tabela de capacidades. |

--- a/astrologo-frontend/functions/api/_shared/analysisJobRepository.ts
+++ b/astrologo-frontend/functions/api/_shared/analysisJobRepository.ts
@@ -356,10 +356,14 @@ export const retryOrFailAnalysisStep = async (options: {
   readonly errorCode: string;
   readonly errorDetail: string;
   readonly retryable?: boolean;
+  /** Negociação de teto de saída: devolve a tentativa consumida pelo claim —
+   * a repetição não conta no orçamento de 3 tentativas. Finita por construção
+   * (o caller só a usa com valores estritamente decrescentes até o piso). */
+  readonly refundAttempt?: boolean;
   readonly inputTokens: number;
   readonly outputTokens: number;
 }): Promise<'retry' | 'failed'> => {
-  const retry = options.retryable !== false && options.step.attempts < 3;
+  const retry = options.refundAttempt === true || (options.retryable !== false && options.step.attempts < 3);
   const batch = requireBatch(options.db);
   const statements = [
     assertJobLeaseStatement(options.db, options.jobId, options.leaseOwner),
@@ -368,6 +372,7 @@ export const retryOrFailAnalysisStep = async (options: {
       .prepare(
         `UPDATE astrologo_ai_analysis_steps
          SET status = ?, payload_json = ?, lease_owner = NULL, lease_expires_at = NULL,
+             attempts = MAX(attempts - ?, 0),
              input_tokens = input_tokens + ?, output_tokens = output_tokens + ?,
              error_code = ?, error_detail = ?, updated_at = datetime('now')
          WHERE job_id = ? AND step_key = ? AND status = 'running' AND lease_owner = ?`,
@@ -375,6 +380,7 @@ export const retryOrFailAnalysisStep = async (options: {
       .bind(
         retry ? 'pending' : 'failed',
         serializeJson(options.payload, `Payload de repetição ${options.step.step_key}`),
+        options.refundAttempt === true ? 1 : 0,
         options.inputTokens,
         options.outputTokens,
         options.errorCode,

--- a/astrologo-frontend/functions/api/analisar.partitioned.test.ts
+++ b/astrologo-frontend/functions/api/analisar.partitioned.test.ts
@@ -9,6 +9,7 @@ const runtime = vi.hoisted(() => ({
   finishReasons: ['STOP'] as string[],
   totalTokens: 100,
   count404Models: [] as string[],
+  outputCapLimit: null as number | null,
   model: 'gemini-3.1-pro-preview',
   fragmentHtml: '<h2>Parte validada</h2><p>Análise fragmentada em português do Brasil.</p>',
   synthesisHtml: '',
@@ -51,6 +52,14 @@ vi.mock('./_shared/vertex', () => {
         generateContent: async (request: Record<string, unknown>) => {
           runtime.generateCalls += 1;
           runtime.generateRequests.push(request);
+          const requestedMax = (request.config as { maxOutputTokens?: number } | undefined)?.maxOutputTokens ?? 0;
+          if (runtime.outputCapLimit !== null && requestedMax > runtime.outputCapLimit) {
+            throw new MockVertexHttpError(
+              `Vertex generateContent falhou (HTTP 400): GenerateContentRequest.generation_config.max_output_tokens must be within limits`,
+              400,
+              'generateContent',
+            );
+          }
           const generateError = runtime.generateErrors.shift();
           if (generateError) throw generateError;
           const config = request.config as
@@ -238,16 +247,21 @@ vi.mock('./_shared/analysisJobRepository', () => {
       step: { attempts: number; step_key: string };
       payload: unknown;
       retryable?: boolean;
+      refundAttempt?: boolean;
       errorCode: string;
       errorDetail: string;
     }) => {
       if (!runtime.job) throw new Error('estado ausente');
       runtime.lastRetryOptions = options;
-      const retry = options.retryable !== false && options.step.attempts < 3;
+      const retry = options.refundAttempt === true || (options.retryable !== false && options.step.attempts < 3);
       const index = runtime.steps.findIndex((step) => step.step_key === options.step.step_key);
       if (index < 0) throw new Error('etapa ausente');
       const retried = {
         ...runtime.steps[index],
+        attempts:
+          options.refundAttempt === true
+            ? Math.max(0, Number(runtime.steps[index]?.attempts) - 1)
+            : Number(runtime.steps[index]?.attempts),
         status: retry ? 'pending' : 'failed',
         payload_json: JSON.stringify(options.payload),
         error_code: options.errorCode,
@@ -381,6 +395,7 @@ beforeEach(() => {
   runtime.finishReasons = ['STOP'];
   runtime.totalTokens = 100;
   runtime.count404Models = [];
+  runtime.outputCapLimit = null;
   runtime.model = 'gemini-3.1-pro-preview';
   runtime.fragmentHtml = '<h2>Parte validada</h2><p>Análise fragmentada em português do Brasil.</p>';
   runtime.directHtml =
@@ -517,6 +532,47 @@ describe('/api/analisar — protocolo reentrante', () => {
     expect((runtime.generateRequests[1] as { config?: { maxOutputTokens?: number } }).config?.maxOutputTokens).toBe(
       4_096,
     );
+  });
+
+  it('a negociação de teto não consome o orçamento de tentativas: alcança o piso de 1.024 e completa', async () => {
+    runtime.model = 'gemini-9.9-ultra';
+    runtime.outputCapLimit = 1_024;
+
+    await onRequestPost(context({ action: 'start', id: MAP_ID }));
+    await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+
+    let final: Response | null = null;
+    for (let i = 0; i < 4; i += 1) {
+      final = await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+      if (final.status === 200) break;
+      expect(final.status).toBe(202);
+    }
+
+    expect(final?.status).toBe(200);
+    expect(
+      runtime.generateRequests.map((r) => (r.config as { maxOutputTokens?: number } | undefined)?.maxOutputTokens),
+    ).toEqual([8_192, 4_096, 2_048, 1_024]);
+  });
+
+  it('lembra o teto rejeitado: a escalada seguinte clampa abaixo dele em vez de oscilar', async () => {
+    runtime.model = 'gemini-9.9-ultra';
+    runtime.outputCapLimit = 16_383;
+    runtime.finishReasons = ['MAX_TOKENS', 'MAX_TOKENS', 'STOP'];
+
+    await onRequestPost(context({ action: 'start', id: MAP_ID }));
+    await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+
+    let final: Response | null = null;
+    for (let i = 0; i < 4; i += 1) {
+      final = await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+      if (final.status === 200) break;
+      expect(final.status).toBe(202);
+    }
+
+    expect(final?.status).toBe(200);
+    expect(
+      runtime.generateRequests.map((r) => (r.config as { maxOutputTokens?: number } | undefined)?.maxOutputTokens),
+    ).toEqual([8_192, 16_384, 8_192, 16_383]);
   });
 
   it('transforma cada tentativa em uma nova requisição e nunca repete dentro do mesmo avanço', async () => {

--- a/astrologo-frontend/functions/api/analisar.ts
+++ b/astrologo-frontend/functions/api/analisar.ts
@@ -1392,6 +1392,7 @@ interface DirectStepPayload {
   readonly contents: string;
   readonly systemInstruction?: string;
   readonly maxOutputTokens: number;
+  readonly outputTokenCeiling?: number;
   readonly sourceEvidenceIds: readonly string[];
 }
 
@@ -1399,6 +1400,7 @@ interface FragmentStepPayload {
   readonly kind: 'fragment';
   readonly fragment: Omit<PackedAnalysisFragment, 'units'>;
   readonly maxOutputTokens: number;
+  readonly outputTokenCeiling?: number;
 }
 
 interface ReductionStepPayload {
@@ -1407,12 +1409,14 @@ interface ReductionStepPayload {
   readonly sources: readonly AnalysisSynthesisSource[];
   readonly expected: AnalysisReductionExpectation;
   readonly maxOutputTokens: number;
+  readonly outputTokenCeiling?: number;
 }
 
 interface SynthesisStepPayload {
   readonly kind: 'synthesis';
   readonly sources: readonly AnalysisSynthesisSource[];
   readonly maxOutputTokens: number;
+  readonly outputTokenCeiling?: number;
 }
 
 type PersistedStepPayload = DirectStepPayload | FragmentStepPayload | ReductionStepPayload | SynthesisStepPayload;
@@ -1977,24 +1981,32 @@ const executeOneAnalysisStep = async (options: {
     return { kind: payload.kind, completed: true };
   } catch (error) {
     const detail = describeErrorChain(error, error instanceof GeminiStepAttemptError ? error.finishReason : undefined);
-    // Adaptação descendente: se o modelo (tipicamente fora da tabela validada)
-    // rejeitar o teto atual com 400 de maxOutputTokens, reduz pela metade
-    // (piso 1.024) e mantém a etapa retryable — o teto real é descoberto em
-    // runtime em vez de assumido, e a escalada ascendente de MAX_TOKENS
-    // continua disponível para respostas longas.
+    // Descoberta de teto em runtime: um 400 de maxOutputTokens registra o teto
+    // rejeitado no payload persistido (outputTokenCeiling) e reduz o valor pela
+    // metade (piso 1.024); a escalada ascendente de MAX_TOKENS clampa no teto
+    // lembrado — sem oscilação nem re-tentativa de valor já rejeitado. A
+    // negociação de teto devolve a tentativa consumida (refundAttempt): como o
+    // halving é estritamente decrescente até o piso, o reembolso é finito.
     const attemptCause = error instanceof GeminiStepAttemptError ? error.cause : undefined;
     const outputCapRejected =
       attemptCause instanceof VertexHttpError &&
       attemptCause.status === 400 &&
       /max_?output_?tokens/iu.test(attemptCause.message) &&
       payload.maxOutputTokens > 1_024;
+    const knownOutputCeiling = Number.isSafeInteger(payload.outputTokenCeiling)
+      ? Math.min(Number(payload.outputTokenCeiling), plan.modelOutputTokenLimit)
+      : plan.modelOutputTokenLimit;
     const retryPayload =
       error instanceof GeminiStepAttemptError &&
       error.finishReason === 'MAX_TOKENS' &&
-      payload.maxOutputTokens < plan.modelOutputTokenLimit
-        ? { ...payload, maxOutputTokens: Math.min(plan.modelOutputTokenLimit, payload.maxOutputTokens * 2) }
+      payload.maxOutputTokens < knownOutputCeiling
+        ? { ...payload, maxOutputTokens: Math.min(knownOutputCeiling, payload.maxOutputTokens * 2) }
         : outputCapRejected
-          ? { ...payload, maxOutputTokens: Math.max(1_024, Math.floor(payload.maxOutputTokens / 2)) }
+          ? {
+              ...payload,
+              outputTokenCeiling: Math.min(knownOutputCeiling, payload.maxOutputTokens - 1),
+              maxOutputTokens: Math.max(1_024, Math.floor(payload.maxOutputTokens / 2)),
+            }
           : payload;
     const retryState = await retryOrFailAnalysisStep({
       db: options.env.BIGDATA_DB,
@@ -2009,6 +2021,7 @@ const executeOneAnalysisStep = async (options: {
             : 'AI_PROVIDER_REQUEST_FAILED'
           : 'AI_STEP_INVALID',
       errorDetail: detail,
+      refundAttempt: outputCapRejected,
       retryable:
         !(error instanceof GeminiStepAttemptError) ||
         error.category === 'validation' ||

--- a/astrologo-frontend/package-lock.json
+++ b/astrologo-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astrologo-frontend",
-  "version": "2.25.2",
+  "version": "2.25.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astrologo-frontend",
-      "version": "2.25.2",
+      "version": "2.25.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@js-temporal/polyfill": "0.5.1",

--- a/astrologo-frontend/package.json
+++ b/astrologo-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astrologo-frontend",
-  "version": "2.25.2",
+  "version": "2.25.3",
   "description": "Astrólogo — gerador de mapas astrais e análises esotéricas via integração Gemini AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.",
   "license": "AGPL-3.0-or-later",
   "author": "LCV Ideas & Software",

--- a/astrologo-frontend/src/App.tsx
+++ b/astrologo-frontend/src/App.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 // Módulo: astrologo-frontend/src/App.tsx
-// Versão: v02.25.02
+// Versão: v02.25.03
 // Descrição: Frontend principal do Oráculo Celestial com análise astrológica via Gemini.
 
 import DOMPurify from 'dompurify';
@@ -73,7 +73,7 @@ import { isSynastryRunV1, renderSynastryRunEmailHtml, renderSynastryRunText } fr
 import { formatTatwaDurationPtBr, presentTatwa } from './tatwaPresentation';
 import { isTransitRunV1, renderTransitRunEmailHtml, renderTransitRunText, type TransitRunV1 } from './transitRunV1';
 
-const APP_VERSION = 'APP v02.25.02';
+const APP_VERSION = 'APP v02.25.03';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const isValidEmail = (value: string): boolean => emailRegex.test(value.trim());


### PR DESCRIPTION
Fecha os dois achados que os bots deixaram no PR #264 (v02.25.02), onde a adaptação de teto em runtime foi introduzida.

## codex (P1): a redução até o piso consumia o orçamento de tentativas

Num modelo cujo teto real é 1.024, a sequência de halving `8.192 → 4.096 → 2.048` gastava as três tentativas do passo e a etapa falhava **antes** de alcançar o piso — ou seja, a adaptação existia mas não chegava a funcionar justamente nos modelos que mais precisavam dela.

`retryOrFailAnalysisStep` ganha `refundAttempt`: quando a repetição é uma negociação de teto (e só nesse caso), a tentativa consumida pelo claim é devolvida (`attempts = MAX(attempts - 1, 0)`), deixando o orçamento de 3 reservado para falhas reais. O reembolso é finito por construção — o caller só o usa com valores estritamente decrescentes até o piso de 1.024.

## Copilot: oscilação entre um teto e o valor já rejeitado

A escalada ascendente de `MAX_TOKENS` podia repropor exatamente o valor que o modelo acabara de recusar (8.192 ↔ 16.384). O 400 de `maxOutputTokens` agora grava o teto rejeitado no payload persistido (`outputTokenCeiling = maxOutputTokens - 1`) e a escalada clampa nele, então nenhum valor já recusado volta a ser tentado — e o limite descoberto sobrevive entre tentativas porque vive no payload, não em memória.

## Verificação

`test` (58 arquivos / 341 testes), `lint`, `biome`, `build` e `git diff --check` — todos exit 0. Versão em todas as superfícies: **v02.25.03** (package.json, lockfile, README raiz e do frontend, SECURITY.md, App.tsx) + entradas de CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)