### PR TITLE
fix(ai): converge output ceiling search — v02.25.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [v02.25.04] - 10/08/2026
+
+**Busca binária do teto real de saída (achado Copilot no PR da v02.25.03).**
+
+### Alterado
+
+- A negociação de `maxOutputTokens` agora persiste tanto o último valor aceito (`outputTokenFloor`) quanto o limite superior derivado dos valores rejeitados (`outputTokenCeiling`) e converge por busca binária. Isso elimina a sequência patológica que voltava a dobrar o valor aceito e reduzia o teto apenas de um em um, consumindo o orçamento de tentativas em modelos com limites não adjacentes, como 8.000 tokens.
+- A regressão cobre a negociação completa de 8.192 até 8.000 e comprova que somente probes que estreitam o intervalo são reembolsados; retries funcionais sem progresso continuam sujeitos ao orçamento normal.
+
 ## [v02.25.03] - 2026-08-09
 
 **Negociação de teto fora do orçamento de tentativas (achados codex P1 + Copilot no PR da v02.25.02).**

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 **Astrólogo** — gerador de mapas astrais e análises esotéricas via integração Gemini AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.
 
-**Status.** Stable. Current release: **v02.25.03**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v02.25.04**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release                              | Scope                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`v02.25.04`**                      | **Busca binária do teto real de saída.** O último valor aceito e o limite superior derivado das rejeições delimitam a negociação de `maxOutputTokens`, que converge sem oscilar nem consumir o orçamento funcional em modelos com limites não adjacentes, como 8.000 tokens.                                                                                            |
 | **`v02.25.03`**                      | **Negociação de teto fora do orçamento.** O 400 de `maxOutputTokens` registra o teto rejeitado no payload (a escalada clampa nele, sem oscilar) e devolve a tentativa consumida — o piso de 1.024 é sempre alcançável.                                                                                                                               |
 | **`v02.25.02`**                      | **Adaptação de teto em runtime.** Modelos fora da tabela voltam a ter headroom de saída (65.535) e o 400 de `maxOutputTokens` passa a ser auto-recuperado por redução pela metade (piso 1.024) no retry da etapa — o teto real é descoberto, não assumido.                                                                                            |
 | **`v02.25.01`**                      | **Hardening pós-review.** Teto conservador de saída para modelos fora da tabela cai para 8.192 (request inicial), lockfile realinhado e changelog paralelo sincronizado.                                                                                                                                                                              |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported status
 
-Latest supported release: v02.25.03. The current main branch is also supported for security fixes until the next release is published.
+Latest supported release: v02.25.04. The current main branch is also supported for security fixes until the next release is published.
 
 ## Reporting a vulnerability
 

--- a/astrologo-frontend/CHANGELOG.md
+++ b/astrologo-frontend/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — Astrólogo Frontend
 
+## [v02.25.04] - 10/08/2026
+
+- A negociação de `maxOutputTokens` persiste o último valor aceito e o limite superior derivado das rejeições e converge por busca binária, evitando oscilação e esgotamento de tentativas em tetos não adjacentes, como 8.000 tokens (achado Copilot do PR anterior).
+
 ## [v02.25.03] - 2026-08-09
 
 - Negociação de teto fora do orçamento: `outputTokenCeiling` persistido no payload clampa a escalada (sem oscilação) e o refund devolve a tentativa da negociação — piso 1.024 sempre alcançável (achados codex P1 + Copilot do PR anterior).

--- a/astrologo-frontend/README.md
+++ b/astrologo-frontend/README.md
@@ -19,12 +19,13 @@ Currently, two official plugins are available:
 
 ## Change History
 
-**Status.** Stable. Current release: **v02.25.03**. See [CHANGELOG.md](../CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v02.25.04**. See [CHANGELOG.md](../CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release     | Notes                                                                                                                                                                   |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `v02.25.04` | Busca binária do teto real de saída: o último valor aceito e o limite superior derivado das rejeições delimitam a negociação de `maxOutputTokens`, sem oscilação nem consumo indevido das tentativas funcionais. |
 | `v02.25.03` | Negociação de teto fora do orçamento de tentativas: teto rejeitado lembrado no payload (escalada clampa nele) e tentativa devolvida no refund — piso 1.024 sempre alcançável. |
 | `v02.25.02` | Headroom de saída restaurado para modelos fora da tabela (65.535) com auto-recuperação descendente no 400 de `maxOutputTokens` (metade, piso 1.024) no retry da etapa. |
 | `v02.25.01` | Teto conservador de saída para modelos fora da tabela: 8.192 (request inicial); lockfile e changelog paralelo realinhados. |

--- a/astrologo-frontend/functions/api/_shared/analysisJobRepository.ts
+++ b/astrologo-frontend/functions/api/_shared/analysisJobRepository.ts
@@ -358,7 +358,7 @@ export const retryOrFailAnalysisStep = async (options: {
   readonly retryable?: boolean;
   /** Negociação de teto de saída: devolve a tentativa consumida pelo claim —
    * a repetição não conta no orçamento de 3 tentativas. Finita por construção
-   * (o caller só a usa com valores estritamente decrescentes até o piso). */
+   * (o caller só a usa quando o intervalo conhecido diminui estritamente). */
   readonly refundAttempt?: boolean;
   readonly inputTokens: number;
   readonly outputTokens: number;

--- a/astrologo-frontend/functions/api/analisar.partitioned.test.ts
+++ b/astrologo-frontend/functions/api/analisar.partitioned.test.ts
@@ -10,6 +10,7 @@ const runtime = vi.hoisted(() => ({
   totalTokens: 100,
   count404Models: [] as string[],
   outputCapLimit: null as number | null,
+  minimumOutputTokensToStop: null as number | null,
   model: 'gemini-3.1-pro-preview',
   fragmentHtml: '<h2>Parte validada</h2><p>Análise fragmentada em português do Brasil.</p>',
   synthesisHtml: '',
@@ -90,9 +91,15 @@ vi.mock('./_shared/vertex', () => {
                 })
               : JSON.stringify({ html: runtime.synthesisHtml, warnings: [] })
             : runtime.directHtml;
+          const finishReason =
+            runtime.minimumOutputTokensToStop === null
+              ? (runtime.finishReasons.shift() ?? 'STOP')
+              : requestedMax >= runtime.minimumOutputTokensToStop
+                ? 'STOP'
+                : 'MAX_TOKENS';
           return {
             text: structuredText,
-            candidates: [{ finishReason: runtime.finishReasons.shift() ?? 'STOP' }],
+            candidates: [{ finishReason }],
             usageMetadata: { promptTokenCount: 1_000, candidatesTokenCount: 100, thoughtsTokenCount: 50 },
           };
         },
@@ -396,6 +403,7 @@ beforeEach(() => {
   runtime.totalTokens = 100;
   runtime.count404Models = [];
   runtime.outputCapLimit = null;
+  runtime.minimumOutputTokensToStop = null;
   runtime.model = 'gemini-3.1-pro-preview';
   runtime.fragmentHtml = '<h2>Parte validada</h2><p>Análise fragmentada em português do Brasil.</p>';
   runtime.directHtml =
@@ -572,7 +580,52 @@ describe('/api/analisar — protocolo reentrante', () => {
     expect(final?.status).toBe(200);
     expect(
       runtime.generateRequests.map((r) => (r.config as { maxOutputTokens?: number } | undefined)?.maxOutputTokens),
-    ).toEqual([8_192, 16_384, 8_192, 16_383]);
+    ).toEqual([8_192, 16_384, 12_288, 14_336]);
+  });
+
+  it('negocia por busca binária um teto não adjacente de 8.000 sem consumir as tentativas funcionais', async () => {
+    runtime.model = 'gemini-9.9-ultra';
+    runtime.outputCapLimit = 8_000;
+    runtime.minimumOutputTokensToStop = 8_000;
+
+    await onRequestPost(context({ action: 'start', id: MAP_ID }));
+    await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+
+    let final: Response | null = null;
+    for (let i = 0; i < 10; i += 1) {
+      final = await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+      if (final.status === 200) break;
+      expect(final.status).toBe(202);
+    }
+
+    expect(final?.status).toBe(200);
+    expect(
+      runtime.generateRequests.map((r) => (r.config as { maxOutputTokens?: number } | undefined)?.maxOutputTokens),
+    ).toEqual([8_192, 4_096, 6_144, 7_168, 7_680, 7_936, 8_064, 8_000]);
+    expect(runtime.step).toMatchObject({ status: 'completed', attempts: 1 });
+  });
+
+  it('volta ao orçamento limitado quando o intervalo fecha sem uma resposta completa', async () => {
+    runtime.model = 'gemini-9.9-ultra';
+    runtime.outputCapLimit = 1_024;
+    runtime.minimumOutputTokensToStop = 2_000;
+
+    await onRequestPost(context({ action: 'start', id: MAP_ID }));
+    await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+
+    let final: Response | null = null;
+    for (let i = 0; i < 24; i += 1) {
+      final = await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+      if (final.status !== 202) break;
+    }
+
+    expect(final?.status).toBe(422);
+    expect(runtime.step).toMatchObject({ status: 'failed', attempts: 3 });
+    expect(
+      runtime.generateRequests
+        .slice(-3)
+        .map((request) => (request.config as { maxOutputTokens?: number } | undefined)?.maxOutputTokens),
+    ).toEqual([1_024, 1_024, 1_024]);
   });
 
   it('transforma cada tentativa em uma nova requisição e nunca repete dentro do mesmo avanço', async () => {

--- a/astrologo-frontend/functions/api/analisar.ts
+++ b/astrologo-frontend/functions/api/analisar.ts
@@ -1393,6 +1393,7 @@ interface DirectStepPayload {
   readonly systemInstruction?: string;
   readonly maxOutputTokens: number;
   readonly outputTokenCeiling?: number;
+  readonly outputTokenFloor?: number;
   readonly sourceEvidenceIds: readonly string[];
 }
 
@@ -1401,6 +1402,7 @@ interface FragmentStepPayload {
   readonly fragment: Omit<PackedAnalysisFragment, 'units'>;
   readonly maxOutputTokens: number;
   readonly outputTokenCeiling?: number;
+  readonly outputTokenFloor?: number;
 }
 
 interface ReductionStepPayload {
@@ -1410,6 +1412,7 @@ interface ReductionStepPayload {
   readonly expected: AnalysisReductionExpectation;
   readonly maxOutputTokens: number;
   readonly outputTokenCeiling?: number;
+  readonly outputTokenFloor?: number;
 }
 
 interface SynthesisStepPayload {
@@ -1417,6 +1420,7 @@ interface SynthesisStepPayload {
   readonly sources: readonly AnalysisSynthesisSource[];
   readonly maxOutputTokens: number;
   readonly outputTokenCeiling?: number;
+  readonly outputTokenFloor?: number;
 }
 
 type PersistedStepPayload = DirectStepPayload | FragmentStepPayload | ReductionStepPayload | SynthesisStepPayload;
@@ -1982,32 +1986,65 @@ const executeOneAnalysisStep = async (options: {
   } catch (error) {
     const detail = describeErrorChain(error, error instanceof GeminiStepAttemptError ? error.finishReason : undefined);
     // Descoberta de teto em runtime: um 400 de maxOutputTokens registra o teto
-    // rejeitado no payload persistido (outputTokenCeiling) e reduz o valor pela
-    // metade (piso 1.024); a escalada ascendente de MAX_TOKENS clampa no teto
-    // lembrado — sem oscilação nem re-tentativa de valor já rejeitado. A
-    // negociação de teto devolve a tentativa consumida (refundAttempt): como o
-    // halving é estritamente decrescente até o piso, o reembolso é finito.
+    // rejeitado no payload persistido (outputTokenCeiling). Um MAX_TOKENS prova
+    // que o valor atual foi aceito pelo provider e o guarda como limite inferior
+    // (outputTokenFloor). Depois da primeira rejeição, os próximos probes usam
+    // busca binária nesse intervalo, sem repetir valores. Probes que estreitam o
+    // intervalo devolvem a tentativa consumida; quando não há mais avanço
+    // possível, o retry funcional volta a ser limitado pelo orçamento normal.
     const attemptCause = error instanceof GeminiStepAttemptError ? error.cause : undefined;
+    const maxOutputExhausted = error instanceof GeminiStepAttemptError && error.finishReason === 'MAX_TOKENS';
     const outputCapRejected =
       attemptCause instanceof VertexHttpError &&
       attemptCause.status === 400 &&
       /max_?output_?tokens/iu.test(attemptCause.message) &&
       payload.maxOutputTokens > 1_024;
-    const knownOutputCeiling = Number.isSafeInteger(payload.outputTokenCeiling)
+    const hasKnownOutputCeiling = Number.isSafeInteger(payload.outputTokenCeiling);
+    const knownOutputCeiling = hasKnownOutputCeiling
       ? Math.min(Number(payload.outputTokenCeiling), plan.modelOutputTokenLimit)
       : plan.modelOutputTokenLimit;
-    const retryPayload =
-      error instanceof GeminiStepAttemptError &&
-      error.finishReason === 'MAX_TOKENS' &&
-      payload.maxOutputTokens < knownOutputCeiling
-        ? { ...payload, maxOutputTokens: Math.min(knownOutputCeiling, payload.maxOutputTokens * 2) }
-        : outputCapRejected
+    const persistedOutputFloor = Number.isSafeInteger(payload.outputTokenFloor)
+      ? Number(payload.outputTokenFloor)
+      : undefined;
+    let retryPayload: PersistedStepPayload = payload;
+    let refundNegotiationProbe = false;
+    if (maxOutputExhausted && payload.maxOutputTokens < knownOutputCeiling) {
+      const acceptedOutputFloor = Math.max(persistedOutputFloor ?? 1_024, payload.maxOutputTokens);
+      const nextMaxOutputTokens = hasKnownOutputCeiling
+        ? acceptedOutputFloor + Math.ceil((knownOutputCeiling - acceptedOutputFloor) / 2)
+        : Math.min(knownOutputCeiling, payload.maxOutputTokens * 2);
+      retryPayload = {
+        ...payload,
+        outputTokenFloor: acceptedOutputFloor,
+        maxOutputTokens: nextMaxOutputTokens,
+      };
+      refundNegotiationProbe = hasKnownOutputCeiling && nextMaxOutputTokens > payload.maxOutputTokens;
+    } else if (outputCapRejected) {
+      const rejectedOutputCeiling = Math.min(knownOutputCeiling, payload.maxOutputTokens - 1);
+      const acceptedOutputFloor =
+        persistedOutputFloor !== undefined &&
+        persistedOutputFloor >= 1_024 &&
+        persistedOutputFloor <= rejectedOutputCeiling
+          ? persistedOutputFloor
+          : undefined;
+      const nextMaxOutputTokens =
+        acceptedOutputFloor !== undefined
+          ? acceptedOutputFloor + Math.ceil((rejectedOutputCeiling - acceptedOutputFloor) / 2)
+          : Math.min(rejectedOutputCeiling, Math.max(1_024, Math.floor(payload.maxOutputTokens / 2)));
+      retryPayload =
+        acceptedOutputFloor === undefined
           ? {
               ...payload,
-              outputTokenCeiling: Math.min(knownOutputCeiling, payload.maxOutputTokens - 1),
-              maxOutputTokens: Math.max(1_024, Math.floor(payload.maxOutputTokens / 2)),
+              outputTokenCeiling: rejectedOutputCeiling,
+              maxOutputTokens: nextMaxOutputTokens,
             }
-          : payload;
+          : {
+              ...payload,
+              outputTokenCeiling: rejectedOutputCeiling,
+              outputTokenFloor: acceptedOutputFloor,
+              maxOutputTokens: nextMaxOutputTokens,
+            };
+    }
     const retryState = await retryOrFailAnalysisStep({
       db: options.env.BIGDATA_DB,
       jobId: options.job.id,
@@ -2021,7 +2058,7 @@ const executeOneAnalysisStep = async (options: {
             : 'AI_PROVIDER_REQUEST_FAILED'
           : 'AI_STEP_INVALID',
       errorDetail: detail,
-      refundAttempt: outputCapRejected,
+      refundAttempt: outputCapRejected || refundNegotiationProbe,
       retryable:
         !(error instanceof GeminiStepAttemptError) ||
         error.category === 'validation' ||

--- a/astrologo-frontend/package-lock.json
+++ b/astrologo-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astrologo-frontend",
-  "version": "2.25.3",
+  "version": "2.25.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astrologo-frontend",
-      "version": "2.25.3",
+      "version": "2.25.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@js-temporal/polyfill": "0.5.1",

--- a/astrologo-frontend/package.json
+++ b/astrologo-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astrologo-frontend",
-  "version": "2.25.3",
+  "version": "2.25.4",
   "description": "Astrólogo — gerador de mapas astrais e análises esotéricas via integração Gemini AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.",
   "license": "AGPL-3.0-or-later",
   "author": "LCV Ideas & Software",

--- a/astrologo-frontend/src/App.tsx
+++ b/astrologo-frontend/src/App.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 // Módulo: astrologo-frontend/src/App.tsx
-// Versão: v02.25.03
+// Versão: v02.25.04
 // Descrição: Frontend principal do Oráculo Celestial com análise astrológica via Gemini.
 
 import DOMPurify from 'dompurify';
@@ -73,7 +73,7 @@ import { isSynastryRunV1, renderSynastryRunEmailHtml, renderSynastryRunText } fr
 import { formatTatwaDurationPtBr, presentTatwa } from './tatwaPresentation';
 import { isTransitRunV1, renderTransitRunEmailHtml, renderTransitRunText, type TransitRunV1 } from './transitRunV1';
 
-const APP_VERSION = 'APP v02.25.03';
+const APP_VERSION = 'APP v02.25.04';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const isValidEmail = (value: string): boolean => emailRegex.test(value.trim());


### PR DESCRIPTION
## Correção

Fecha o achado do Copilot no PR #265. Depois de descobrir que um valor excedia o teto real do modelo, a implementação voltava a dobrar o último valor aceito e reduzia o limite superior apenas de um em um. Em tetos não adjacentes, como 8.000, isso consumia o orçamento e encerrava a análise com 422.

A v02.25.04 persiste o último valor aceito (`outputTokenFloor`) e o limite superior derivado das rejeições (`outputTokenCeiling`) e converge por busca binária.

## Regressão e limites

- RED anterior: teto 8.000 terminava em 422;
- sequência verde: `8192 → 4096 → 6144 → 7168 → 7680 → 7936 → 8064 → 8000`;
- probes que estreitam o intervalo são reembolsados;
- quando o intervalo fecha sem resposta completa, o reembolso cessa e a etapa falha após as três tentativas normais.

## Validação

- testes focados: 20/20;
- suíte integral: 58 arquivos, 343 testes;
- ESLint, Biome, TypeScript, Vite build e Public Format verdes;
- `git diff --check` verde;
- versão, lockfile, UI, READMEs, SECURITY e changelogs sincronizados em v02.25.04.

Achado original: https://github.com/LCV-Ideas-Software/astrologo-app/pull/265#discussion_r3746348773