### PR TITLE
fix(ai): persist provider output bounds — v02.25.05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [v02.25.05] - 10/08/2026
+
+**Limites de saída reaproveitados com segurança entre etapas (achados Copilot e Codex no PR da v02.25.04).**
+
+### Alterado
+
+- O plano persistido do job agora compartilha, somente para o mesmo modelo imutável, o menor teto rejeitado e o maior limite de saída aceito. Fragmentos, reduções e síntese reutilizam essa descoberta, evitando repetir a negociação e reduzindo chamadas e pressão de rate limit.
+- Uma rejeição posterior do provedor invalida automaticamente qualquer limite aceito que tenha ficado acima do novo teto. O piso local obsoleto da etapa também é descartado, permitindo retomar a busca binária sem intervalo contraditório.
+- As atualizações do plano, da etapa e da contabilidade de tokens são gravadas no mesmo lote D1 sob o lease exclusivo do job; planos anteriores permanecem compatíveis porque os novos campos são opcionais.
+
 ## [v02.25.04] - 10/08/2026
 
 **Busca binária do teto real de saída (achado Copilot no PR da v02.25.03).**

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 **Astrólogo** — gerador de mapas astrais e análises esotéricas via integração Gemini AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.
 
-**Status.** Stable. Current release: **v02.25.04**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v02.25.05**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release                              | Scope                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`v02.25.05`**                      | **Limites reaproveitados entre etapas.** O job persiste o teto rejeitado e o maior limite aceito pelo provedor para o mesmo modelo, reutiliza a descoberta nos fragmentos seguintes e invalida automaticamente limites ou pisos que uma rejeição posterior torne obsoletos.                                                                                       |
 | **`v02.25.04`**                      | **Busca binária do teto real de saída.** O último valor aceito e o limite superior derivado das rejeições delimitam a negociação de `maxOutputTokens`, que converge sem oscilar nem consumir o orçamento funcional em modelos com limites não adjacentes, como 8.000 tokens.                                                                                            |
 | **`v02.25.03`**                      | **Negociação de teto fora do orçamento.** O 400 de `maxOutputTokens` registra o teto rejeitado no payload (a escalada clampa nele, sem oscilar) e devolve a tentativa consumida — o piso de 1.024 é sempre alcançável.                                                                                                                               |
 | **`v02.25.02`**                      | **Adaptação de teto em runtime.** Modelos fora da tabela voltam a ter headroom de saída (65.535) e o 400 de `maxOutputTokens` passa a ser auto-recuperado por redução pela metade (piso 1.024) no retry da etapa — o teto real é descoberto, não assumido.                                                                                            |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported status
 
-Latest supported release: v02.25.04. The current main branch is also supported for security fixes until the next release is published.
+Latest supported release: v02.25.05. The current main branch is also supported for security fixes until the next release is published.
 
 ## Reporting a vulnerability
 

--- a/astrologo-frontend/CHANGELOG.md
+++ b/astrologo-frontend/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — Astrólogo Frontend
 
+## [v02.25.05] - 10/08/2026
+
+- O teto rejeitado e o limite aceito pelo provedor passam a ser persistidos por job/modelo e reutilizados entre fragmentos, reduções e síntese; uma rejeição posterior invalida limites e pisos obsoletos, evitando chamadas repetidas sem tornar o teto permanente (achados Copilot e Codex do PR anterior).
+
 ## [v02.25.04] - 10/08/2026
 
 - A negociação de `maxOutputTokens` persiste o último valor aceito e o limite superior derivado das rejeições e converge por busca binária, evitando oscilação e esgotamento de tentativas em tetos não adjacentes, como 8.000 tokens (achado Copilot do PR anterior).

--- a/astrologo-frontend/README.md
+++ b/astrologo-frontend/README.md
@@ -19,12 +19,13 @@ Currently, two official plugins are available:
 
 ## Change History
 
-**Status.** Stable. Current release: **v02.25.04**. See [CHANGELOG.md](../CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v02.25.05**. See [CHANGELOG.md](../CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release     | Notes                                                                                                                                                                   |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `v02.25.05` | Persiste e reutiliza os limites de saída aceitos pelo provedor entre etapas do mesmo job/modelo e invalida limites ou pisos que uma rejeição posterior torne obsoletos. |
 | `v02.25.04` | Busca binária do teto real de saída: o último valor aceito e o limite superior derivado das rejeições delimitam a negociação de `maxOutputTokens`, sem oscilação nem consumo indevido das tentativas funcionais. |
 | `v02.25.03` | Negociação de teto fora do orçamento de tentativas: teto rejeitado lembrado no payload (escalada clampa nele) e tentativa devolvida no refund — piso 1.024 sempre alcançável. |
 | `v02.25.02` | Headroom de saída restaurado para modelos fora da tabela (65.535) com auto-recuperação descendente no 400 de `maxOutputTokens` (metade, piso 1.024) no retry da etapa. |

--- a/astrologo-frontend/functions/api/_shared/analysisJobRepository.ts
+++ b/astrologo-frontend/functions/api/_shared/analysisJobRepository.ts
@@ -310,6 +310,7 @@ export const completeAnalysisStep = async (options: {
   readonly jobId: string;
   readonly leaseOwner: string;
   readonly stepKey: string;
+  readonly plan: unknown;
   readonly result: unknown;
   readonly inputTokens: number;
   readonly outputTokens: number;
@@ -338,12 +339,18 @@ export const completeAnalysisStep = async (options: {
     options.db
       .prepare(
         `UPDATE astrologo_ai_analysis_jobs
-         SET completed_steps = completed_steps + 1,
+         SET plan_json = ?, completed_steps = completed_steps + 1,
              input_tokens = input_tokens + ?, output_tokens = output_tokens + ?,
              updated_at = datetime('now')
          WHERE id = ? AND lease_owner = ?`,
       )
-      .bind(options.inputTokens, options.outputTokens, options.jobId, options.leaseOwner),
+      .bind(
+        serializeJson(options.plan, 'Plano após conclusão da etapa'),
+        options.inputTokens,
+        options.outputTokens,
+        options.jobId,
+        options.leaseOwner,
+      ),
   ]);
 };
 
@@ -352,6 +359,7 @@ export const retryOrFailAnalysisStep = async (options: {
   readonly jobId: string;
   readonly leaseOwner: string;
   readonly step: AnalysisStepRecord;
+  readonly plan: unknown;
   readonly payload: unknown;
   readonly errorCode: string;
   readonly errorDetail: string;
@@ -394,10 +402,17 @@ export const retryOrFailAnalysisStep = async (options: {
     options.db
       .prepare(
         `UPDATE astrologo_ai_analysis_jobs
-         SET input_tokens = input_tokens + ?, output_tokens = output_tokens + ?, updated_at = datetime('now')
+         SET plan_json = ?, input_tokens = input_tokens + ?, output_tokens = output_tokens + ?,
+             updated_at = datetime('now')
          WHERE id = ? AND lease_owner = ?`,
       )
-      .bind(options.inputTokens, options.outputTokens, options.jobId, options.leaseOwner),
+      .bind(
+        serializeJson(options.plan, 'Plano após tentativa da etapa'),
+        options.inputTokens,
+        options.outputTokens,
+        options.jobId,
+        options.leaseOwner,
+      ),
   );
   if (!retry) {
     statements.push(

--- a/astrologo-frontend/functions/api/analisar.partitioned.test.ts
+++ b/astrologo-frontend/functions/api/analisar.partitioned.test.ts
@@ -227,6 +227,7 @@ vi.mock('./_shared/analysisJobRepository', () => {
     },
     completeAnalysisStep: async (options: {
       stepKey: string;
+      plan: unknown;
       result: unknown;
       inputTokens: number;
       outputTokens: number;
@@ -245,6 +246,7 @@ vi.mock('./_shared/analysisJobRepository', () => {
       runtime.step = completed;
       runtime.job = {
         ...runtime.job,
+        plan_json: JSON.stringify(options.plan),
         completed_steps: Number(runtime.job.completed_steps) + 1,
         input_tokens: Number(runtime.job.input_tokens) + options.inputTokens,
         output_tokens: Number(runtime.job.output_tokens) + options.outputTokens,
@@ -252,6 +254,7 @@ vi.mock('./_shared/analysisJobRepository', () => {
     },
     retryOrFailAnalysisStep: async (options: {
       step: { attempts: number; step_key: string };
+      plan: unknown;
       payload: unknown;
       retryable?: boolean;
       refundAttempt?: boolean;
@@ -260,6 +263,7 @@ vi.mock('./_shared/analysisJobRepository', () => {
     }) => {
       if (!runtime.job) throw new Error('estado ausente');
       runtime.lastRetryOptions = options;
+      runtime.job = { ...runtime.job, plan_json: JSON.stringify(options.plan) };
       const retry = options.refundAttempt === true || (options.retryable !== false && options.step.attempts < 3);
       const index = runtime.steps.findIndex((step) => step.step_key === options.step.step_key);
       if (index < 0) throw new Error('etapa ausente');
@@ -603,6 +607,103 @@ describe('/api/analisar — protocolo reentrante', () => {
       runtime.generateRequests.map((r) => (r.config as { maxOutputTokens?: number } | undefined)?.maxOutputTokens),
     ).toEqual([8_192, 4_096, 6_144, 7_168, 7_680, 7_936, 8_064, 8_000]);
     expect(runtime.step).toMatchObject({ status: 'completed', attempts: 1 });
+  });
+
+  it('descarta o piso da etapa quando uma nova rejeição prova que ele ficou acima do teto', async () => {
+    runtime.model = 'gemini-9.9-ultra';
+
+    await onRequestPost(context({ action: 'start', id: MAP_ID }));
+    await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+    if (!runtime.steps[0]) throw new Error('etapa de teste ausente');
+    runtime.steps[0] = {
+      ...runtime.steps[0],
+      payload_json: JSON.stringify({
+        ...JSON.parse(String(runtime.steps[0].payload_json)),
+        maxOutputTokens: 8_192,
+        outputTokenCeiling: 8_192,
+        outputTokenFloor: 8_192,
+      }),
+    };
+    runtime.outputCapLimit = 4_096;
+
+    const rejected = await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+    const retryPayload = JSON.parse(String(runtime.steps[0].payload_json)) as Record<string, unknown>;
+
+    expect(rejected.status).toBe(202);
+    expect(retryPayload).toMatchObject({ outputTokenCeiling: 8_191, maxOutputTokens: 4_096 });
+    expect(retryPayload).not.toHaveProperty('outputTokenFloor');
+  });
+
+  it('reutiliza no fragmento seguinte o limite aceito descoberto para o mesmo job e modelo', async () => {
+    runtime.model = 'gemini-9.9-ultra';
+    runtime.totalTokens = 6_001;
+    runtime.outputCapLimit = 8_000;
+    runtime.minimumOutputTokensToStop = 8_000;
+
+    await onRequestPost(context({ action: 'start', id: MAP_ID }));
+    await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+    if (!runtime.job || !runtime.steps[0]) throw new Error('plano particionado de teste ausente');
+    runtime.steps.push({
+      ...runtime.steps[0],
+      step_key: 'fragment:0002',
+      ordinal: 2,
+    });
+    runtime.job = { ...runtime.job, total_steps: Number(runtime.job.total_steps) + 1 };
+
+    for (let i = 0; i < 10 && runtime.steps[0]?.status !== 'completed'; i += 1) {
+      await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+    }
+
+    expect(runtime.steps[0]).toMatchObject({ status: 'completed' });
+    expect(runtime.generateCalls).toBe(8);
+    expect(JSON.parse(String(runtime.job.plan_json))).toMatchObject({
+      providerOutputTokenCeiling: 8_063,
+      providerAcceptedOutputTokenLimit: 8_000,
+    });
+
+    await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+
+    expect(runtime.steps[1]).toMatchObject({ status: 'completed' });
+    expect(runtime.generateCalls).toBe(9);
+    expect((runtime.generateRequests.at(-1)?.config as { maxOutputTokens?: number } | undefined)?.maxOutputTokens).toBe(
+      8_000,
+    );
+  });
+
+  it('invalida o limite aceito compartilhado quando o provedor reduz o teto numa etapa posterior', async () => {
+    runtime.model = 'gemini-9.9-ultra';
+    runtime.totalTokens = 6_001;
+    runtime.outputCapLimit = 8_000;
+    runtime.minimumOutputTokensToStop = 8_000;
+
+    await onRequestPost(context({ action: 'start', id: MAP_ID }));
+    await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+    if (!runtime.job || !runtime.steps[0]) throw new Error('plano particionado de teste ausente');
+    runtime.steps.push({
+      ...runtime.steps[0],
+      step_key: 'fragment:0002',
+      ordinal: 2,
+    });
+    runtime.job = { ...runtime.job, total_steps: Number(runtime.job.total_steps) + 1 };
+
+    for (let i = 0; i < 10 && runtime.steps[0]?.status !== 'completed'; i += 1) {
+      await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+    }
+    expect(JSON.parse(String(runtime.job.plan_json))).toMatchObject({
+      providerOutputTokenCeiling: 8_063,
+      providerAcceptedOutputTokenLimit: 8_000,
+    });
+
+    runtime.outputCapLimit = 4_096;
+    const rejected = await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+    const persistedPlan = JSON.parse(String(runtime.job.plan_json)) as Record<string, unknown>;
+
+    expect(rejected.status).toBe(202);
+    expect((runtime.generateRequests.at(-1)?.config as { maxOutputTokens?: number } | undefined)?.maxOutputTokens).toBe(
+      8_000,
+    );
+    expect(persistedPlan).toMatchObject({ providerOutputTokenCeiling: 7_999 });
+    expect(persistedPlan).not.toHaveProperty('providerAcceptedOutputTokenLimit');
   });
 
   it('volta ao orçamento limitado quando o intervalo fecha sem uma resposta completa', async () => {

--- a/astrologo-frontend/functions/api/analisar.partitioned.test.ts
+++ b/astrologo-frontend/functions/api/analisar.partitioned.test.ts
@@ -670,6 +670,56 @@ describe('/api/analisar — protocolo reentrante', () => {
     );
   });
 
+  it('promove o teto legado da etapa para o plano antes de reutilizá-lo no fragmento seguinte', async () => {
+    runtime.model = 'gemini-9.9-ultra';
+    runtime.totalTokens = 6_001;
+    runtime.outputCapLimit = 8_063;
+    runtime.minimumOutputTokensToStop = 8_032;
+
+    await onRequestPost(context({ action: 'start', id: MAP_ID }));
+    await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+    if (!runtime.job || !runtime.steps[0]) throw new Error('plano particionado de teste ausente');
+    runtime.steps.push({
+      ...runtime.steps[0],
+      step_key: 'fragment:0002',
+      ordinal: 2,
+    });
+    runtime.steps[0] = {
+      ...runtime.steps[0],
+      payload_json: JSON.stringify({
+        ...JSON.parse(String(runtime.steps[0].payload_json)),
+        maxOutputTokens: 8_000,
+        outputTokenCeiling: 8_063,
+        outputTokenFloor: 8_000,
+      }),
+    };
+    runtime.job = { ...runtime.job, total_steps: Number(runtime.job.total_steps) + 1 };
+
+    for (let i = 0; i < 4 && runtime.steps[0]?.status !== 'completed'; i += 1) {
+      await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+    }
+
+    expect(runtime.steps[0]).toMatchObject({ status: 'completed' });
+    expect(JSON.parse(String(runtime.job.plan_json))).toMatchObject({
+      providerOutputTokenCeiling: 8_063,
+      providerAcceptedOutputTokenLimit: 8_032,
+    });
+
+    runtime.minimumOutputTokensToStop = 8_063;
+    const retried = await onRequestPost(context({ action: 'advance', jobId: JOB_ID, capability: CAPABILITY }));
+    const retryPayload = JSON.parse(String(runtime.steps[1]?.payload_json)) as Record<string, unknown>;
+
+    expect(retried.status).toBe(202);
+    expect((runtime.generateRequests.at(-1)?.config as { maxOutputTokens?: number } | undefined)?.maxOutputTokens).toBe(
+      8_032,
+    );
+    expect(retryPayload).toMatchObject({
+      outputTokenCeiling: 8_063,
+      outputTokenFloor: 8_032,
+      maxOutputTokens: 8_048,
+    });
+  });
+
   it('invalida o limite aceito compartilhado quando o provedor reduz o teto numa etapa posterior', async () => {
     runtime.model = 'gemini-9.9-ultra';
     runtime.totalTokens = 6_001;

--- a/astrologo-frontend/functions/api/analisar.ts
+++ b/astrologo-frontend/functions/api/analisar.ts
@@ -1378,6 +1378,10 @@ interface PersistedAnalysisJobPlan {
   readonly model: string;
   readonly modelInputTokenLimit: number;
   readonly modelOutputTokenLimit: number;
+  /** Menor limite superior conhecido após uma rejeição do provider. */
+  readonly providerOutputTokenCeiling?: number;
+  /** Maior configuração de saída que o provider já aceitou neste job/model. */
+  readonly providerAcceptedOutputTokenLimit?: number;
   readonly fragmentOutputBudget: number;
   readonly synthesisInputBudget: number;
   readonly inputHash: string;
@@ -1503,6 +1507,14 @@ const loadPersistedJobPlan = (job: AnalysisJobRecord): PersistedAnalysisJobPlan 
     typeof value.model !== 'string' ||
     !Number.isSafeInteger(value.modelInputTokenLimit) ||
     !Number.isSafeInteger(value.modelOutputTokenLimit) ||
+    (value.providerOutputTokenCeiling !== undefined &&
+      (!Number.isSafeInteger(value.providerOutputTokenCeiling) || Number(value.providerOutputTokenCeiling) < 1_024)) ||
+    (value.providerAcceptedOutputTokenLimit !== undefined &&
+      (!Number.isSafeInteger(value.providerAcceptedOutputTokenLimit) ||
+        Number(value.providerAcceptedOutputTokenLimit) < 1_024)) ||
+    (Number.isSafeInteger(value.providerOutputTokenCeiling) &&
+      Number.isSafeInteger(value.providerAcceptedOutputTokenLimit) &&
+      Number(value.providerAcceptedOutputTokenLimit) > Number(value.providerOutputTokenCeiling)) ||
     !Number.isSafeInteger(value.fragmentOutputBudget) ||
     !Number.isSafeInteger(value.synthesisInputBudget) ||
     typeof value.inputHash !== 'string' ||
@@ -1520,6 +1532,12 @@ const loadPersistedJobPlan = (job: AnalysisJobRecord): PersistedAnalysisJobPlan 
   const currentModelProfile = resolveVertexAnalysisModel(persisted.model);
   const modelInputTokenLimit = Math.min(persisted.modelInputTokenLimit, currentModelProfile.inputTokenLimit);
   const modelOutputTokenLimit = Math.min(persisted.modelOutputTokenLimit, currentModelProfile.outputTokenLimit);
+  const providerOutputTokenCeiling = Number.isSafeInteger(persisted.providerOutputTokenCeiling)
+    ? Math.min(Number(persisted.providerOutputTokenCeiling), modelOutputTokenLimit)
+    : undefined;
+  const providerAcceptedOutputTokenLimit = Number.isSafeInteger(persisted.providerAcceptedOutputTokenLimit)
+    ? Math.min(Number(persisted.providerAcceptedOutputTokenLimit), providerOutputTokenCeiling ?? modelOutputTokenLimit)
+    : undefined;
   const fragmentOutputBudget = Math.min(persisted.fragmentOutputBudget, modelOutputTokenLimit);
   const synthesisInputBudget = Math.min(
     persisted.synthesisInputBudget,
@@ -1531,8 +1549,45 @@ const loadPersistedJobPlan = (job: AnalysisJobRecord): PersistedAnalysisJobPlan 
     model: currentModelProfile.model,
     modelInputTokenLimit,
     modelOutputTokenLimit,
+    ...(providerOutputTokenCeiling !== undefined ? { providerOutputTokenCeiling } : {}),
+    ...(providerAcceptedOutputTokenLimit !== undefined ? { providerAcceptedOutputTokenLimit } : {}),
     fragmentOutputBudget,
     synthesisInputBudget,
+  };
+};
+
+const withProviderOutputBounds = (
+  plan: PersistedAnalysisJobPlan,
+  update: {
+    readonly rejectedCeiling?: number;
+    readonly acceptedLimit?: number;
+  },
+): PersistedAnalysisJobPlan => {
+  const nextCeiling = Math.min(
+    plan.providerOutputTokenCeiling ?? plan.modelOutputTokenLimit,
+    update.rejectedCeiling ?? plan.modelOutputTokenLimit,
+  );
+  const currentAccepted =
+    plan.providerAcceptedOutputTokenLimit !== undefined && plan.providerAcceptedOutputTokenLimit <= nextCeiling
+      ? plan.providerAcceptedOutputTokenLimit
+      : undefined;
+  const candidateAccepted =
+    update.acceptedLimit !== undefined && update.acceptedLimit <= nextCeiling ? update.acceptedLimit : undefined;
+  const nextAccepted =
+    currentAccepted === undefined
+      ? candidateAccepted
+      : candidateAccepted === undefined
+        ? currentAccepted
+        : Math.max(currentAccepted, candidateAccepted);
+  const base = { ...plan };
+  delete base.providerOutputTokenCeiling;
+  delete base.providerAcceptedOutputTokenLimit;
+  return {
+    ...base,
+    ...(plan.providerOutputTokenCeiling !== undefined || update.rejectedCeiling !== undefined
+      ? { providerOutputTokenCeiling: nextCeiling }
+      : {}),
+    ...(nextAccepted !== undefined ? { providerAcceptedOutputTokenLimit: nextAccepted } : {}),
   };
 };
 
@@ -1845,6 +1900,15 @@ const executeOneAnalysisStep = async (options: {
   const plan = loadPersistedJobPlan(options.job);
   const packedPlan = plan.packedPlan ? hydratePackedPlan(plan.packedPlan) : undefined;
   const payload = loadStepPayload(options.step);
+  const stepHasOutputBounds =
+    Number.isSafeInteger(payload.outputTokenCeiling) || Number.isSafeInteger(payload.outputTokenFloor);
+  const attemptedMaxOutputTokens = Math.min(
+    payload.maxOutputTokens,
+    plan.providerOutputTokenCeiling ?? plan.modelOutputTokenLimit,
+    !stepHasOutputBounds && Number.isSafeInteger(plan.providerAcceptedOutputTokenLimit)
+      ? Number(plan.providerAcceptedOutputTokenLimit)
+      : plan.modelOutputTokenLimit,
+  );
   const ai = await createGeminiClient(options.env);
   const usageTotals: AiUsageTotals = { inputTokens: 0, outputTokens: 0, thinkingTokens: 0, calls: 0 };
   const startedAt = Date.now();
@@ -1857,7 +1921,7 @@ const executeOneAnalysisStep = async (options: {
         model: plan.model,
         contents: payload.contents,
         ...(payload.systemInstruction ? { systemInstruction: payload.systemInstruction } : {}),
-        initialMaxOutputTokens: payload.maxOutputTokens,
+        initialMaxOutputTokens: attemptedMaxOutputTokens,
         modelOutputTokenLimit: plan.modelOutputTokenLimit,
         usageTotals,
         stage: 'análise integral direta',
@@ -1880,7 +1944,7 @@ const executeOneAnalysisStep = async (options: {
         model: plan.model,
         contents: buildFragmentGenerationInput(fragment),
         systemInstruction: LONG_ANALYSIS_SYSTEM_INSTRUCTION,
-        initialMaxOutputTokens: payload.maxOutputTokens,
+        initialMaxOutputTokens: attemptedMaxOutputTokens,
         modelOutputTokenLimit: plan.modelOutputTokenLimit,
         responseJsonSchema: fragmentResponseSchema(fragment),
         usageTotals,
@@ -1915,7 +1979,7 @@ const executeOneAnalysisStep = async (options: {
           payload.expected,
         ),
         systemInstruction: LONG_ANALYSIS_SYSTEM_INSTRUCTION,
-        initialMaxOutputTokens: payload.maxOutputTokens,
+        initialMaxOutputTokens: attemptedMaxOutputTokens,
         modelOutputTokenLimit: plan.modelOutputTokenLimit,
         responseJsonSchema: reductionResponseSchema(payload.expected),
         usageTotals,
@@ -1947,7 +2011,7 @@ const executeOneAnalysisStep = async (options: {
         model: plan.model,
         contents: buildSynthesisGenerationInput(options.job.fixed_prompt_prefix, packedPlan, payload.sources),
         systemInstruction: LONG_ANALYSIS_SYSTEM_INSTRUCTION,
-        initialMaxOutputTokens: payload.maxOutputTokens,
+        initialMaxOutputTokens: attemptedMaxOutputTokens,
         modelOutputTokenLimit: plan.modelOutputTokenLimit,
         responseJsonSchema: synthesisResponseSchema(),
         usageTotals,
@@ -1970,6 +2034,7 @@ const executeOneAnalysisStep = async (options: {
       jobId: options.job.id,
       leaseOwner: options.leaseOwner,
       stepKey: options.step.step_key,
+      plan: withProviderOutputBounds(plan, { acceptedLimit: attemptedMaxOutputTokens }),
       result,
       inputTokens: usageTotals.inputTokens,
       outputTokens: usageTotals.outputTokens,
@@ -1998,29 +2063,37 @@ const executeOneAnalysisStep = async (options: {
       attemptCause instanceof VertexHttpError &&
       attemptCause.status === 400 &&
       /max_?output_?tokens/iu.test(attemptCause.message) &&
-      payload.maxOutputTokens > 1_024;
-    const hasKnownOutputCeiling = Number.isSafeInteger(payload.outputTokenCeiling);
-    const knownOutputCeiling = hasKnownOutputCeiling
-      ? Math.min(Number(payload.outputTokenCeiling), plan.modelOutputTokenLimit)
-      : plan.modelOutputTokenLimit;
+      attemptedMaxOutputTokens > 1_024;
+    const hasKnownOutputCeiling =
+      Number.isSafeInteger(payload.outputTokenCeiling) || Number.isSafeInteger(plan.providerOutputTokenCeiling);
+    const knownOutputCeiling = Math.min(
+      Number.isSafeInteger(payload.outputTokenCeiling)
+        ? Number(payload.outputTokenCeiling)
+        : plan.modelOutputTokenLimit,
+      plan.providerOutputTokenCeiling ?? plan.modelOutputTokenLimit,
+      plan.modelOutputTokenLimit,
+    );
     const persistedOutputFloor = Number.isSafeInteger(payload.outputTokenFloor)
       ? Number(payload.outputTokenFloor)
       : undefined;
     let retryPayload: PersistedStepPayload = payload;
+    let retryPlan = plan;
     let refundNegotiationProbe = false;
-    if (maxOutputExhausted && payload.maxOutputTokens < knownOutputCeiling) {
-      const acceptedOutputFloor = Math.max(persistedOutputFloor ?? 1_024, payload.maxOutputTokens);
+    if (maxOutputExhausted && attemptedMaxOutputTokens < knownOutputCeiling) {
+      const acceptedOutputFloor = Math.max(persistedOutputFloor ?? 1_024, attemptedMaxOutputTokens);
       const nextMaxOutputTokens = hasKnownOutputCeiling
         ? acceptedOutputFloor + Math.ceil((knownOutputCeiling - acceptedOutputFloor) / 2)
-        : Math.min(knownOutputCeiling, payload.maxOutputTokens * 2);
+        : Math.min(knownOutputCeiling, attemptedMaxOutputTokens * 2);
       retryPayload = {
         ...payload,
+        ...(hasKnownOutputCeiling ? { outputTokenCeiling: knownOutputCeiling } : {}),
         outputTokenFloor: acceptedOutputFloor,
         maxOutputTokens: nextMaxOutputTokens,
       };
-      refundNegotiationProbe = hasKnownOutputCeiling && nextMaxOutputTokens > payload.maxOutputTokens;
+      retryPlan = withProviderOutputBounds(plan, { acceptedLimit: attemptedMaxOutputTokens });
+      refundNegotiationProbe = hasKnownOutputCeiling && nextMaxOutputTokens > attemptedMaxOutputTokens;
     } else if (outputCapRejected) {
-      const rejectedOutputCeiling = Math.min(knownOutputCeiling, payload.maxOutputTokens - 1);
+      const rejectedOutputCeiling = Math.min(knownOutputCeiling, attemptedMaxOutputTokens - 1);
       const acceptedOutputFloor =
         persistedOutputFloor !== undefined &&
         persistedOutputFloor >= 1_024 &&
@@ -2030,11 +2103,13 @@ const executeOneAnalysisStep = async (options: {
       const nextMaxOutputTokens =
         acceptedOutputFloor !== undefined
           ? acceptedOutputFloor + Math.ceil((rejectedOutputCeiling - acceptedOutputFloor) / 2)
-          : Math.min(rejectedOutputCeiling, Math.max(1_024, Math.floor(payload.maxOutputTokens / 2)));
+          : Math.min(rejectedOutputCeiling, Math.max(1_024, Math.floor(attemptedMaxOutputTokens / 2)));
+      const payloadWithoutOutputFloor = { ...payload };
+      delete payloadWithoutOutputFloor.outputTokenFloor;
       retryPayload =
         acceptedOutputFloor === undefined
           ? {
-              ...payload,
+              ...payloadWithoutOutputFloor,
               outputTokenCeiling: rejectedOutputCeiling,
               maxOutputTokens: nextMaxOutputTokens,
             }
@@ -2044,12 +2119,14 @@ const executeOneAnalysisStep = async (options: {
               outputTokenFloor: acceptedOutputFloor,
               maxOutputTokens: nextMaxOutputTokens,
             };
+      retryPlan = withProviderOutputBounds(plan, { rejectedCeiling: rejectedOutputCeiling });
     }
     const retryState = await retryOrFailAnalysisStep({
       db: options.env.BIGDATA_DB,
       jobId: options.job.id,
       leaseOwner: options.leaseOwner,
       step: options.step,
+      plan: retryPlan,
       payload: retryPayload,
       errorCode:
         error instanceof GeminiStepAttemptError

--- a/astrologo-frontend/functions/api/analisar.ts
+++ b/astrologo-frontend/functions/api/analisar.ts
@@ -1900,6 +1900,9 @@ const executeOneAnalysisStep = async (options: {
   const plan = loadPersistedJobPlan(options.job);
   const packedPlan = plan.packedPlan ? hydratePackedPlan(plan.packedPlan) : undefined;
   const payload = loadStepPayload(options.step);
+  const persistedOutputCeiling = Number.isSafeInteger(payload.outputTokenCeiling)
+    ? Math.min(Number(payload.outputTokenCeiling), plan.modelOutputTokenLimit)
+    : undefined;
   const stepHasOutputBounds =
     Number.isSafeInteger(payload.outputTokenCeiling) || Number.isSafeInteger(payload.outputTokenFloor);
   const attemptedMaxOutputTokens = Math.min(
@@ -2034,7 +2037,10 @@ const executeOneAnalysisStep = async (options: {
       jobId: options.job.id,
       leaseOwner: options.leaseOwner,
       stepKey: options.step.step_key,
-      plan: withProviderOutputBounds(plan, { acceptedLimit: attemptedMaxOutputTokens }),
+      plan: withProviderOutputBounds(plan, {
+        ...(persistedOutputCeiling !== undefined ? { rejectedCeiling: persistedOutputCeiling } : {}),
+        acceptedLimit: attemptedMaxOutputTokens,
+      }),
       result,
       inputTokens: usageTotals.inputTokens,
       outputTokens: usageTotals.outputTokens,
@@ -2090,7 +2096,10 @@ const executeOneAnalysisStep = async (options: {
         outputTokenFloor: acceptedOutputFloor,
         maxOutputTokens: nextMaxOutputTokens,
       };
-      retryPlan = withProviderOutputBounds(plan, { acceptedLimit: attemptedMaxOutputTokens });
+      retryPlan = withProviderOutputBounds(plan, {
+        ...(persistedOutputCeiling !== undefined ? { rejectedCeiling: persistedOutputCeiling } : {}),
+        acceptedLimit: attemptedMaxOutputTokens,
+      });
       refundNegotiationProbe = hasKnownOutputCeiling && nextMaxOutputTokens > attemptedMaxOutputTokens;
     } else if (outputCapRejected) {
       const rejectedOutputCeiling = Math.min(knownOutputCeiling, attemptedMaxOutputTokens - 1);

--- a/astrologo-frontend/package-lock.json
+++ b/astrologo-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astrologo-frontend",
-  "version": "2.25.4",
+  "version": "2.25.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astrologo-frontend",
-      "version": "2.25.4",
+      "version": "2.25.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@js-temporal/polyfill": "0.5.1",

--- a/astrologo-frontend/package.json
+++ b/astrologo-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astrologo-frontend",
-  "version": "2.25.4",
+  "version": "2.25.5",
   "description": "Astrólogo — gerador de mapas astrais e análises esotéricas via integração Gemini AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.",
   "license": "AGPL-3.0-or-later",
   "author": "LCV Ideas & Software",

--- a/astrologo-frontend/src/App.tsx
+++ b/astrologo-frontend/src/App.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 // Módulo: astrologo-frontend/src/App.tsx
-// Versão: v02.25.04
+// Versão: v02.25.05
 // Descrição: Frontend principal do Oráculo Celestial com análise astrológica via Gemini.
 
 import DOMPurify from 'dompurify';
@@ -73,7 +73,7 @@ import { isSynastryRunV1, renderSynastryRunEmailHtml, renderSynastryRunText } fr
 import { formatTatwaDurationPtBr, presentTatwa } from './tatwaPresentation';
 import { isTransitRunV1, renderTransitRunEmailHtml, renderTransitRunText, type TransitRunV1 } from './transitRunV1';
 
-const APP_VERSION = 'APP v02.25.04';
+const APP_VERSION = 'APP v02.25.05';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const isValidEmail = (value: string): boolean => emailRegex.test(value.trim());


### PR DESCRIPTION
## Resumo

- persiste por job/modelo o menor teto rejeitado e o maior limite de saída aceito;
- reutiliza a descoberta em fragmentos, reduções e síntese, reduzindo chamadas repetidas;
- invalida limites e pisos obsoletos quando o provedor reduz o teto;
- publica a correção como v02.25.05 e mantém os dois changelogs e marcadores de versão alinhados.

## Proveniência

Corrige os dois achados funcionais pós-merge do PR #268. Os comentários sobre datas ISO não se aplicam: changelogs são superfícies humanas e seguem pt-BR/Brasília.

## Validação

- RED→GREEN para piso obsoleto, reutilização entre fragmentos e invalidação do limite compartilhado;
- Vitest serial: 58 arquivos / 346 testes;
- ESLint e Biome;
- TypeScript + Vite build;
- Cloudflare Pages Functions build;
- npm audit: 0 vulnerabilidades;
- git diff --check.

O PR permanece em draft até a leitura cumulativa dos dois bots e a janela silenciosa.