### PR TITLE
fix(ci): bootstrap native auto-merge v2.1.4

### DIFF
--- a/.github/workflows/native-auto-merge.yml
+++ b/.github/workflows/native-auto-merge.yml
@@ -6,29 +6,62 @@ on:
       - CodeQL
     types:
       - completed
+  pull_request_target:
+    types:
+      - review_requested
 
 permissions: write-all
 
 concurrency:
-  group: native-auto-merge-${{ github.repository }}-${{ github.event.workflow_run.head_sha || github.sha }}
+  group: native-auto-merge-${{ github.repository }}-${{ github.event.workflow_run.id || github.run_id }}
   cancel-in-progress: false
 
 jobs:
   enable:
     name: Enable native auto-merge
-    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    if: >-
+      ${{
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.event == 'pull_request'
+        ) ||
+        (
+          github.event_name == 'pull_request_target' &&
+          github.event.action == 'review_requested' &&
+          github.event.requested_reviewer.id == 175728472 &&
+          github.event.pull_request.base.ref == 'main' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        )
+      }}
     runs-on: ubuntu-latest
     permissions: write-all
     environment: dependabot-automation
-    timeout-minutes: 5
+    timeout-minutes: 30
     steps:
       - name: Enable GitHub native auto-merge
-        uses: LCV-Ideas-Software/.github/native-auto-merge@4058fad11eca7c2eb4e9296108667ef6199a6356 # v2.0.0
+        if: ${{ github.event_name == 'workflow_run' }}
+        uses: LCV-Ideas-Software/.github/native-auto-merge@231cd33f27c260a6b01fec26aa1d0eb606e1ee2d # native-auto-merge/v2.1.4
         with:
           automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}
           event_repository: ${{ github.event.repository.full_name }}
           workflow_name: ${{ github.event.workflow_run.name }}
+          workflow_path: ${{ github.event.workflow_run.path }}
+          workflow_display_title: ${{ github.event.workflow_run.display_title }}
           workflow_status: ${{ github.event.workflow_run.status }}
           workflow_event: ${{ github.event.workflow_run.event }}
           workflow_head_sha: ${{ github.event.workflow_run.head_sha }}
+          workflow_actor_id: ${{ github.event.workflow_run.actor.id }}
           workflow_pull_requests: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+      - name: Reconcile requested Copilot review
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: LCV-Ideas-Software/.github/native-auto-merge@231cd33f27c260a6b01fec26aa1d0eb606e1ee2d # native-auto-merge/v2.1.4
+        with:
+          automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}
+          event_repository: ${{ github.event.repository.full_name }}
+          event_action: ${{ github.event.action }}
+          pull_number: ${{ github.event.pull_request.number }}
+          pull_head_sha: ${{ github.event.pull_request.head.sha }}
+          pull_head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          pull_base_ref: ${{ github.event.pull_request.base.ref }}
+          requested_reviewer_id: ${{ github.event.requested_reviewer.id }}
+          trigger_run_id: ${{ github.run_id }}


### PR DESCRIPTION
## O que muda

- atualiza as duas invocações do controller central para `231cd33f27c260a6b01fec26aa1d0eb606e1ee2d # native-auto-merge/v2.1.4`;
- preserva o wrapper consumidor canônico, sem checkout nem execução de conteúdo do PR;
- não inclui ainda o gate de `merge_group`: ele será entregue em um segundo PR após este bootstrap chegar à `main`.

## Motivo

O controller precisa existir na branch padrão antes que um PR posterior consiga comprovar, em execução real, os wake-ups `pull_request_target` e `workflow_run` da v2.1.4. Separar o bootstrap evita usar o próprio PR de implantação como prova circular.

## Impacto

Nenhuma alteração no aplicativo ou em dependências de runtime. O diff é restrito ao wrapper de automação e mantém os refs externos imutáveis por SHA.

## Validação

- commit local assinado e verificado;
- wrapper byte-idêntico ao canário Oráculo já validado;
- `actionlint`;
- Zizmor offline: zero findings, apenas os dois ignores privilegiados documentados;
- base conferida contra o SHA exato atual de `origin/main`.

Este PR permanece em draft até checks, os dois bots revisores e a janela de silêncio serem auditados.