### PR TITLE
fix(ci): alinhar Dependency Review e contrato do rollout

### DIFF
--- a/.github/scripts/trusted-dependency-review.mjs
+++ b/.github/scripts/trusted-dependency-review.mjs
@@ -7,7 +7,7 @@ import { pathToFileURL } from "node:url";
 
 const API_VERSION = "2022-11-28";
 const SNAPSHOT_WARNINGS_HEADER = "x-github-dependency-graph-snapshot-warnings";
-const DEPENDENCY_PAGE_SIZE = 100;
+const DEPENDENCY_PAGE_SIZE = 5;
 const MAX_DEPENDENCY_PAGES = 1_000;
 const MAX_PACKAGE_JSON_BYTES = 128 * 1024;
 const MAX_PACKAGE_LOCK_BYTES = 1024 * 1024;
@@ -137,7 +137,7 @@ const LEAST_PRIVILEGE_ROLLOUT = [
   [
     ".github/workflows/zizmor.yml",
     "c163e87b4faa65fec369a65eea1ca7957a25a9ed",
-    "ba97a86fdf9324d9843397483a055e6fcb05078c",
+    "949fbdd1794f812729500b5f4fcb849cfb3d7266",
   ],
   [
     ".github/scripts/enforce-scorecard.mjs",
@@ -152,7 +152,7 @@ const LEAST_PRIVILEGE_ROLLOUT = [
   [
     ".github/scripts/scorecard-workflow.test.mjs",
     "5237744f213ad3908851a96101e042bce898ca9a",
-    "8eda6286d7bcf4c6f401baf61cb99f40bc8c145e",
+    "45d6d0b21cc896ba3c25a36790bcff3f36bf17ad",
   ],
   [
     ".github/zizmor.yml",

--- a/.github/scripts/trusted-dependency-review.test.mjs
+++ b/.github/scripts/trusted-dependency-review.test.mjs
@@ -76,7 +76,7 @@ const LEAST_PRIVILEGE_ROLLOUT_TRANSITIONS = [
   [
     ".github/workflows/zizmor.yml",
     "c163e87b4faa65fec369a65eea1ca7957a25a9ed",
-    "ba97a86fdf9324d9843397483a055e6fcb05078c",
+    "949fbdd1794f812729500b5f4fcb849cfb3d7266",
   ],
   [
     ".github/scripts/enforce-scorecard.mjs",
@@ -91,7 +91,7 @@ const LEAST_PRIVILEGE_ROLLOUT_TRANSITIONS = [
   [
     ".github/scripts/scorecard-workflow.test.mjs",
     "5237744f213ad3908851a96101e042bce898ca9a",
-    "8eda6286d7bcf4c6f401baf61cb99f40bc8c145e",
+    "45d6d0b21cc896ba3c25a36790bcff3f36bf17ad",
   ],
   [
     ".github/zizmor.yml",
@@ -455,7 +455,7 @@ function dependencyReviewRun(
         [...endpoint.searchParams.entries()].sort(),
         [
           ["page", endpoint.searchParams.get("page")],
-          ["per_page", "100"],
+          ["per_page", "5"],
         ].sort(),
       );
       const page = Number.parseInt(endpoint.searchParams.get("page"), 10);
@@ -2091,7 +2091,7 @@ test("npm lock topology, bundled payloads and every occurrence fail closed", asy
 });
 
 test("dependency review output matches two complete warning-free reads", async () => {
-  const next = `<https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=100&page=2>; rel="next", <https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=100&page=2>; rel="last"`;
+  const next = `<https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=5&page=2>; rel="next", <https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=5&page=2>; rel="last"`;
   await assert.doesNotReject(
     dependencyReviewRun(
       [
@@ -2128,7 +2128,7 @@ test("dependency review output matches two complete warning-free reads", async (
 });
 
 test("dependency snapshot warnings, drift and malformed output fail closed", async () => {
-  const next = `<https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=100&page=2>; rel="next"`;
+  const next = `<https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=5&page=2>; rel="next"`;
   const cleanReads = () => [
     dependencyResponse(DEPENDENCY_CHANGES),
     dependencyResponse(DEPENDENCY_CHANGES),
@@ -2150,25 +2150,25 @@ test("dependency snapshot warnings, drift and malformed output fail closed", asy
     () =>
       dependencyReviewRun([
         dependencyResponse(
-          Array.from({ length: 101 }, () => DEPENDENCY_CHANGES[0]),
+          Array.from({ length: 6 }, () => DEPENDENCY_CHANGES[0]),
         ),
       ]),
     () =>
       dependencyReviewRun([
         dependencyResponse([], {
-          link: `<https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=100&page=3>; rel="next"`,
+          link: `<https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=5&page=3>; rel="next"`,
         }),
       ]),
     () =>
       dependencyReviewRun([
         dependencyResponse([], {
-          link: `<https://example.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=100&page=2>; rel="next"`,
+          link: `<https://example.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=5&page=2>; rel="next"`,
         }),
       ]),
     () =>
       dependencyReviewRun([
         dependencyResponse([], {
-          link: `<https://api.github.com/repos/another/repository/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=100&page=2>; rel="next"`,
+          link: `<https://api.github.com/repos/another/repository/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=5&page=2>; rel="next"`,
         }),
       ]),
     () =>
@@ -2178,7 +2178,7 @@ test("dependency snapshot warnings, drift and malformed output fail closed", asy
     () =>
       dependencyReviewRun([
         dependencyResponse([], {
-          link: `<https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=100&page=9>; rel="last"`,
+          link: `<https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=5&page=9>; rel="last"`,
         }),
       ]),
     () => dependencyReviewRun(cleanReads(), [DEPENDENCY_CHANGES[0]]),
@@ -2202,13 +2202,13 @@ test("dependency snapshot warnings, drift and malformed output fail closed", asy
     () =>
       dependencyReviewRun([
         dependencyResponse([], {
-          link: `garbage, <https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=100&page=2>; rel="next"`,
+          link: `garbage, <https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=5&page=2>; rel="next"`,
         }),
       ]),
     () =>
       dependencyReviewRun([
         dependencyResponse([], {
-          link: `<https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=100&page=2&unexpected=1>; rel="next"`,
+          link: `<https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=5&page=2&unexpected=1>; rel="next"`,
         }),
       ]),
     () =>
@@ -2517,17 +2517,35 @@ test("the pull request binding is checked before and after tree inspection", asy
 });
 
 test("verifyCandidate always carries a supplied comparison through both lockfiles", async () => {
-  const { baseTree, headTree } = preRolloutFixtures();
   const { expected, pull } = expectedPullRequest();
-  const projectBlobs = new Map();
-  const lockOids = new Set();
-  for (const path of [
+  const projectPaths = [
     "package.json",
     "package-lock.json",
     "astrologo-frontend/package.json",
     "astrologo-frontend/package-lock.json",
-  ]) {
-    const bytes = await readFile(resolvePath(path));
+  ];
+  const projectBytes = new Map(
+    await Promise.all(
+      projectPaths.map(async (path) => [
+        path,
+        await readFile(resolvePath(path)),
+      ]),
+    ),
+  );
+  const frontendPackageTransition = LEAST_PRIVILEGE_ROLLOUT_BY_PATH.get(
+    "astrologo-frontend/package.json",
+  );
+  const checkedInFrontendPackageOid = gitBlobOid(
+    projectBytes.get("astrologo-frontend/package.json"),
+  );
+  const { baseTree, headTree } =
+    checkedInFrontendPackageOid === frontendPackageTransition.beforeOid
+      ? preRolloutFixtures()
+      : settledFixtures();
+  const projectBlobs = new Map();
+  const lockOids = new Set();
+  for (const path of projectPaths) {
+    const bytes = projectBytes.get(path);
     const oid = gitBlobOid(bytes);
     for (const tree of [baseTree, headTree]) {
       const entry = tree.tree.find((candidate) => candidate.path === path);
@@ -2867,11 +2885,16 @@ test("the trusted workflow never checks out or executes candidate content", asyn
     gitBlobOid(Buffer.from(finalWorkflow, "utf8")),
     FINAL_TRUSTED_DEPENDENCY_REVIEW_OID,
   );
+  const checkedInCarrierOid = gitBlobOid(Buffer.from(workflow, "utf8"));
+  const carrierTransition = LEAST_PRIVILEGE_ROLLOUT_BY_PATH.get(
+    ".github/workflows/native-auto-merge.yml",
+  );
   assert.equal(
-    gitBlobOid(Buffer.from(workflow, "utf8")),
-    LEAST_PRIVILEGE_ROLLOUT_BY_PATH.get(
-      ".github/workflows/native-auto-merge.yml",
-    ).beforeOid,
+    [carrierTransition.beforeOid, carrierTransition.afterOid].includes(
+      checkedInCarrierOid,
+    ),
+    true,
+    "the checked-in trusted carrier must remain an exact reviewed BEFORE or AFTER blob",
   );
   assert.doesNotMatch(
     workflow,


### PR DESCRIPTION
**Autoria:** correção e análise produzidas por **Codex (OpenAI, GPT-5)** em 14/08/2026.

## Causas comprovadas

O rollout final #294 revelou quatro incompatibilidades fail-closed:

1. a action pinada usa `per_page=5` e recebeu 21 mudanças; o scanner usava 100 e recebeu 18;
2. o teste do carrier ainda exigia somente o blob BEFORE, embora o estado settled use o AFTER já revisado;
3. uma fixture de lock misturava package/lock AFTER com árvore BEFORE;
4. o caller Zizmor mínimo apontava o reusable `v2.0.0`, que declarava `write-all` e causava `startup_failure`; o sucessor oficial assinado `v2.2.0` usa grants mínimos.

A fonte oficial do pin `actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294` usa `octo.paginate` com `per_page: 5` e publica diretamente `JSON.stringify(comparison.changes)`:

- https://github.com/actions/dependency-review-action/blob/a1d282b36b6f3519aa1f3fc636f609c47dddb294/src/dependency-graph.ts#L26-L46
- https://github.com/actions/dependency-review-action/blob/a1d282b36b6f3519aa1f3fc636f609c47dddb294/src/main.ts#L121-L132
- https://github.com/actions/dependency-review-action/blob/a1d282b36b6f3519aa1f3fc636f609c47dddb294/src/main.ts#L225

## Correção root mínima

Este commit assinado, filho direto da `main` `d1c01d7bd8fd2a5586240ef27111d676203a91bd`, muda somente scanner+teste:

- paginação do endpoint dependency review: 100 → 5; descoberta de PRs permanece 100;
- carrier checked-in deve ser exatamente um dos blobs BEFORE/AFTER revisados;
- fixture escolhe uma fase atômica coerente;
- mapa do rollout autoriza os novos blobs finais do caller Zizmor v2.2.0 e seu teste contratual.

Permanecem as duas leituras completas, header de snapshot por página, schema estrito, paginação fail-closed, igualdade canônica com a action e transição atômica exata.

## Evidência

- API live no mesmo base/head: 21 mudanças com 5; 18 com 100;
- REDs reproduziram os quatro problemas;
- GREEN focalizado: 4/4;
- `node --check`, Prettier, Actionlint pontual e `git diff --check`: verdes;
- sucessor Zizmor `97627f2a1d70e59d6868e0d682c988d05b63e88c`: assinatura `valid`, grants exatos `actions:read`, `contents:read`, `security-events:write`;
- AFTER OIDs: Zizmor `949fbdd1794f812729500b5f4fcb849cfb3d7266`; teste `45d6d0b21cc896ba3c25a36790bcff3f36bf17ad`;
- Ultrabrain da paginação: confiança 0,98;
- Cross Review `72890d62-23c5-4638-987c-e385db049895`: zero NOT_READY/finding técnico; prova final remetida ao CI/bots deste SHA.

O #294 permanece sem auto-merge e será atualizado sobre esta raiz somente após o #295 entrar com segurança.

Refs #278
Refs #294