### PR TITLE
fix(ci): aceitar envelope de paginação do Dependency Review

### DIFF
--- a/.github/scripts/trusted-dependency-review.mjs
+++ b/.github/scripts/trusted-dependency-review.mjs
@@ -9,6 +9,7 @@ const API_VERSION = "2022-11-28";
 const SNAPSHOT_WARNINGS_HEADER = "x-github-dependency-graph-snapshot-warnings";
 const DEPENDENCY_PAGE_SIZE = 5;
 const MAX_DEPENDENCY_PAGES = 1_000;
+const MAX_DEPENDENCY_CHANGES = 5_000;
 const MAX_PACKAGE_JSON_BYTES = 128 * 1024;
 const MAX_PACKAGE_LOCK_BYTES = 1024 * 1024;
 const MAX_REGISTRY_METADATA_BYTES = 256 * 1024;
@@ -137,7 +138,7 @@ const LEAST_PRIVILEGE_ROLLOUT = [
   [
     ".github/workflows/zizmor.yml",
     "c163e87b4faa65fec369a65eea1ca7957a25a9ed",
-    "949fbdd1794f812729500b5f4fcb849cfb3d7266",
+    "63df6af729c3ec830df340eb5ccea00e564b575d",
   ],
   [
     ".github/scripts/enforce-scorecard.mjs",
@@ -152,7 +153,7 @@ const LEAST_PRIVILEGE_ROLLOUT = [
   [
     ".github/scripts/scorecard-workflow.test.mjs",
     "5237744f213ad3908851a96101e042bce898ca9a",
-    "45d6d0b21cc896ba3c25a36790bcff3f36bf17ad",
+    "0e03f7c735ea4ef3977e82d9f67512d863ca56b7",
   ],
   [
     ".github/zizmor.yml",
@@ -1802,6 +1803,11 @@ function normalizeDependencyChange(change, label) {
 
 function canonicalDependencyChanges(changes, label) {
   assert.equal(Array.isArray(changes), true, `${label} must be an array`);
+  assert.equal(
+    changes.length <= MAX_DEPENDENCY_CHANGES,
+    true,
+    `${label} exceeded the reviewed total change limit`,
+  );
   return changes
     .map((change, index) =>
       JSON.stringify(normalizeDependencyChange(change, `${label}[${index}]`)),
@@ -1924,15 +1930,15 @@ async function readDependencyComparison({
       "dependency comparison page must be an array",
     );
     assert.equal(
-      pageChanges.length <= DEPENDENCY_PAGE_SIZE,
+      pageChanges.length <= MAX_DEPENDENCY_CHANGES - changes.length,
       true,
-      "dependency comparison page exceeded the reviewed page size",
+      "dependency comparison exceeded the reviewed total change limit",
     );
-    changes.push(
-      ...pageChanges.map((change, index) =>
+    for (const [index, change] of pageChanges.entries()) {
+      changes.push(
         normalizeDependencyChange(change, `comparison page ${page}[${index}]`),
-      ),
-    );
+      );
+    }
     if (
       !hasNextDependencyPage(
         response.headers.get("link"),

--- a/.github/scripts/trusted-dependency-review.test.mjs
+++ b/.github/scripts/trusted-dependency-review.test.mjs
@@ -76,7 +76,7 @@ const LEAST_PRIVILEGE_ROLLOUT_TRANSITIONS = [
   [
     ".github/workflows/zizmor.yml",
     "c163e87b4faa65fec369a65eea1ca7957a25a9ed",
-    "949fbdd1794f812729500b5f4fcb849cfb3d7266",
+    "63df6af729c3ec830df340eb5ccea00e564b575d",
   ],
   [
     ".github/scripts/enforce-scorecard.mjs",
@@ -91,7 +91,7 @@ const LEAST_PRIVILEGE_ROLLOUT_TRANSITIONS = [
   [
     ".github/scripts/scorecard-workflow.test.mjs",
     "5237744f213ad3908851a96101e042bce898ca9a",
-    "45d6d0b21cc896ba3c25a36790bcff3f36bf17ad",
+    "0e03f7c735ea4ef3977e82d9f67512d863ca56b7",
   ],
   [
     ".github/zizmor.yml",
@@ -2127,6 +2127,40 @@ test("dependency review output matches two complete warning-free reads", async (
   );
 });
 
+test("dependency pagination accepts the live 2/18/2 response shape", async () => {
+  const changes = Array.from({ length: 22 }, (_, index) =>
+    dependencyChange("added", `example-package-${index}`, "1.0.0"),
+  );
+  const comparisonUrl = `https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=5`;
+  const firstLink = `<${comparisonUrl}&page=2>; rel="next", <${comparisonUrl}&page=3>; rel="last"`;
+  const middleLink = `<${comparisonUrl}&page=1>; rel="first", <${comparisonUrl}&page=1>; rel="prev", <${comparisonUrl}&page=3>; rel="next", <${comparisonUrl}&page=3>; rel="last"`;
+  const pages = [changes.slice(0, 2), changes.slice(2, 20), changes.slice(20)];
+  await assert.doesNotReject(
+    dependencyReviewRun(
+      [...pages, ...pages].map((page, index) =>
+        dependencyResponse(page, {
+          link:
+            index % pages.length === 0
+              ? firstLink
+              : index % pages.length === 1
+                ? middleLink
+                : undefined,
+        }),
+      ),
+      [...changes].reverse(),
+      [1, 2, 3, 1, 2, 3],
+    ),
+  );
+});
+
+test("dependency comparison rejects total change overflow", async () => {
+  const overflow = Array.from({ length: 5_001 }, () => DEPENDENCY_CHANGES[0]);
+  await assert.rejects(
+    dependencyReviewRun([dependencyResponse(overflow)], []),
+    /dependency comparison exceeded the reviewed total change limit/,
+  );
+});
+
 test("dependency snapshot warnings, drift and malformed output fail closed", async () => {
   const next = `<https://api.github.com/repositories/1182022862/dependency-graph/compare/${SHA.base}...${SHA.head}?per_page=5&page=2>; rel="next"`;
   const cleanReads = () => [
@@ -2147,12 +2181,6 @@ test("dependency snapshot warnings, drift and malformed output fail closed", asy
       dependencyReviewRun([dependencyResponse([], { includeWarning: false })]),
     () => dependencyReviewRun([dependencyResponse([], { status: 500 })]),
     () => dependencyReviewRun([dependencyResponse({}, { link: undefined })]),
-    () =>
-      dependencyReviewRun([
-        dependencyResponse(
-          Array.from({ length: 6 }, () => DEPENDENCY_CHANGES[0]),
-        ),
-      ]),
     () =>
       dependencyReviewRun([
         dependencyResponse([], {


### PR DESCRIPTION
**Autoria:** correção e análise produzidas por **Codex (OpenAI, GPT-5)** em 14/08/2026.

## Causa comprovada

O run `31771635747` mostrou que `per_page=5` não limita o array `changes` a cinco itens: o endpoint retornou páginas `2/18/2`. A action oficial pinada `a1d282b...` usa `octo.paginate(... per_page: 5)` e valida o array retornado, sem impor `changes.length <= 5`. O scanner confundia o hint de paginação com o tamanho do array e falhava fechado por uma premissa incorreta.

## Correção mínima

- preserva `per_page=5`, igual ao binário oficial executado;
- remove somente o teto incorreto por página;
- mantém Link exato, warning header vazio por página, schema, duas leituras e igualdade canônica integral;
- adiciona teto total fail-closed de 5.000 mudanças, aplicado à saída da action e às leituras independentes;
- atualiza os dois AFTER OIDs do rollout para o caller assinado `zizmor/v2.3.1` (`f90943a…`) e seu teste contratual, sem ampliar o conjunto de 15 caminhos.

## Evidência focada

- RED: página válida com 18 itens era rejeitada;
- GREEN: shape `2/18/2` passa nas duas leituras;
- RED/GREEN: 5.001 mudanças falham pelo teto total;
- paginação focada 4/4 e transição/OIDs 2/2, `node --check`, Prettier e `git diff --check` verdes;
- delta exato de dois arquivos;
- commit direto, assinado e verificado `153408c899a75668aa8c487645018b463ac3a835`, pai `8c361e2fdfaa297ab1ac78ae8753a63b423d3488` e trailer de rotação válido.

Blobs finais da raiz: scanner `ee80f4e2b084f1c668acc2bdba582b917f387feb`; teste `be72aa625ef79df7ee20b3ffb8e20128b12801f5`. A [release central v2.3.1](https://github.com/LCV-Ideas-Software/.github/releases/tag/zizmor/v2.3.1) é assinada, imutável e aponta ao squash `f90943a06122468b316c05bb88403d2df451b9f8`.

O Ultrabrain `astrologo-dependency-page-size-20260814` foi revisado explicitamente com o contraexemplo remoto. O CI e os bots deste SHA são a prova autoritativa; não haverá nova bateria local.

Desbloqueia #294. Relacionado a #278 e à Discussion #150.