### PR TITLE
fix(ci): bind direct npm dependency comparisons

### DIFF
--- a/.github/scripts/trusted-dependency-review.mjs
+++ b/.github/scripts/trusted-dependency-review.mjs
@@ -9,7 +9,7 @@ const API_VERSION = "2022-11-28";
 const SNAPSHOT_WARNINGS_HEADER = "x-github-dependency-graph-snapshot-warnings";
 const DEPENDENCY_PAGE_SIZE = 5;
 const MAX_DEPENDENCY_PAGES = 1_000;
-const MAX_DEPENDENCY_CHANGES = 5_000;
+export const MAX_DEPENDENCY_CHANGES = 5_000;
 const MAX_PACKAGE_JSON_BYTES = 128 * 1024;
 const MAX_PACKAGE_LOCK_BYTES = 1024 * 1024;
 const MAX_REGISTRY_METADATA_BYTES = 256 * 1024;
@@ -153,7 +153,7 @@ const LEAST_PRIVILEGE_ROLLOUT = [
   [
     ".github/scripts/scorecard-workflow.test.mjs",
     "5237744f213ad3908851a96101e042bce898ca9a",
-    "0e03f7c735ea4ef3977e82d9f67512d863ca56b7",
+    "61d44c38f1f813db8eab6927e2f9f9ea1288e415",
   ],
   [
     ".github/zizmor.yml",
@@ -202,6 +202,12 @@ const REVIEWED_NPM_PROJECTS = [
     manifest: "astrologo-frontend/package-lock.json",
     packagePath: "astrologo-frontend/package.json",
   },
+];
+const NPM_DIRECT_DEPENDENCY_SECTIONS = [
+  ["dependencies", "runtime"],
+  ["devDependencies", "development"],
+  ["optionalDependencies", "runtime"],
+  ["peerDependencies", "runtime"],
 ];
 const REVIEWED_PACKAGE_EMBEDDED_CONFIG_KEYS = [
   "biome",
@@ -1000,6 +1006,105 @@ function comparisonIdentity(change, manifest, changeType) {
     : null;
 }
 
+function directPackageDependencies(packageJson, label) {
+  const dependencies = new Map();
+  for (const [section, scope] of NPM_DIRECT_DEPENDENCY_SECTIONS) {
+    const values = packageJson[section];
+    if (values === undefined) continue;
+    assert.equal(
+      isPlainObject(values),
+      true,
+      `${label} ${section} must be an object`,
+    );
+    for (const name of Object.keys(values).sort()) {
+      const version = values[name];
+      assert.equal(
+        typeof version === "string" &&
+          version.length > 0 &&
+          version.trim() === version,
+        true,
+        `${label} ${section}.${name} must be a non-empty dependency version`,
+      );
+      assert.equal(
+        dependencies.has(name),
+        false,
+        `${label} dependency ${name} appears in multiple npm sections`,
+      );
+      dependencies.set(name, { name, scope, section, version });
+    }
+  }
+  return dependencies;
+}
+
+function directDependencyRecord(changeType, dependency) {
+  return {
+    change_type: changeType,
+    name: dependency.name,
+    scope: dependency.scope,
+    version: dependency.version,
+  };
+}
+
+function canonicalDirectDependencyChanges(changes) {
+  return changes.map(canonicalDescriptor).sort();
+}
+
+function assertDirectPackageManifestComparison({
+  basePackage,
+  headPackage,
+  comparison,
+  packagePath,
+}) {
+  const base = directPackageDependencies(basePackage, `base ${packagePath}`);
+  const head = directPackageDependencies(
+    headPackage,
+    `candidate ${packagePath}`,
+  );
+  const expected = [];
+  for (const name of new Set([...base.keys(), ...head.keys()])) {
+    const before = base.get(name);
+    const after = head.get(name);
+    if (
+      before !== undefined &&
+      after !== undefined &&
+      canonicalDescriptor(before) === canonicalDescriptor(after)
+    ) {
+      continue;
+    }
+    if (
+      before !== undefined &&
+      after !== undefined &&
+      before.section !== after.section
+    ) {
+      assert.fail(
+        `${packagePath} dependency ${name} moved between npm sections; section changes require a trusted lockfile rotation`,
+      );
+    }
+    if (before !== undefined)
+      expected.push(directDependencyRecord("removed", before));
+    if (after !== undefined)
+      expected.push(directDependencyRecord("added", after));
+  }
+
+  const actual = comparison
+    .filter(
+      (change) => change.ecosystem === "npm" && change.manifest === packagePath,
+    )
+    .map((change) => {
+      assert.equal(
+        change.scope === "runtime" || change.scope === "development",
+        true,
+        `${packagePath} direct dependency scope must be explicit`,
+      );
+      return directDependencyRecord(change.change_type, change);
+    });
+  assert.deepEqual(
+    canonicalDirectDependencyChanges(actual),
+    canonicalDirectDependencyChanges(expected),
+    `${packagePath} direct dependency changes must match package.json`,
+  );
+}
+
 function identityDelta(left, right) {
   const delta = [];
   for (const identity of left.keys())
@@ -1229,7 +1334,10 @@ export async function assertReviewedNpmLocks({
     ),
   );
   const reviewedManifests = new Set(
-    REVIEWED_NPM_PROJECTS.map(({ manifest }) => manifest),
+    REVIEWED_NPM_PROJECTS.flatMap(({ manifest, packagePath }) => [
+      manifest,
+      packagePath,
+    ]),
   );
   for (const change of normalizedComparison) {
     if (change.ecosystem === "npm") {
@@ -1276,6 +1384,12 @@ export async function assertReviewedNpmLocks({
           label: "candidate",
         }),
       ]);
+    assertDirectPackageManifestComparison({
+      basePackage: basePackageBlob.json,
+      headPackage: headPackageBlob.json,
+      comparison: normalizedComparison,
+      packagePath,
+    });
     for (const [label, value] of [
       ["base", baseLockBlob],
       ["candidate", headLockBlob],
@@ -1801,13 +1915,17 @@ function normalizeDependencyChange(change, label) {
   return normalized;
 }
 
-function canonicalDependencyChanges(changes, label) {
-  assert.equal(Array.isArray(changes), true, `${label} must be an array`);
+function assertDependencyChangeLimit(length, label) {
   assert.equal(
-    changes.length <= MAX_DEPENDENCY_CHANGES,
+    length <= MAX_DEPENDENCY_CHANGES,
     true,
     `${label} exceeded the reviewed total change limit`,
   );
+}
+
+function canonicalDependencyChanges(changes, label) {
+  assert.equal(Array.isArray(changes), true, `${label} must be an array`);
+  assertDependencyChangeLimit(changes.length, label);
   return changes
     .map((change, index) =>
       JSON.stringify(normalizeDependencyChange(change, `${label}[${index}]`)),
@@ -1929,10 +2047,9 @@ async function readDependencyComparison({
       true,
       "dependency comparison page must be an array",
     );
-    assert.equal(
-      pageChanges.length <= MAX_DEPENDENCY_CHANGES - changes.length,
-      true,
-      "dependency comparison exceeded the reviewed total change limit",
+    assertDependencyChangeLimit(
+      changes.length + pageChanges.length,
+      "dependency comparison",
     );
     for (const [index, change] of pageChanges.entries()) {
       changes.push(

--- a/.github/scripts/trusted-dependency-review.test.mjs
+++ b/.github/scripts/trusted-dependency-review.test.mjs
@@ -8,6 +8,7 @@ import {
   FINAL_DEPENDENCY_REVIEW_OID,
   FINAL_TRUSTED_DEPENDENCY_REVIEW,
   FINAL_TRUSTED_DEPENDENCY_REVIEW_OID,
+  MAX_DEPENDENCY_CHANGES,
   assertCandidateTree,
   assertDependencyReviewComplete,
   assertReviewedNpmLocks,
@@ -91,7 +92,7 @@ const LEAST_PRIVILEGE_ROLLOUT_TRANSITIONS = [
   [
     ".github/scripts/scorecard-workflow.test.mjs",
     "5237744f213ad3908851a96101e042bce898ca9a",
-    "0e03f7c735ea4ef3977e82d9f67512d863ca56b7",
+    "61d44c38f1f813db8eab6927e2f9f9ea1288e415",
   ],
   [
     ".github/zizmor.yml",
@@ -330,6 +331,138 @@ function reviewedLockFixtures() {
     headTree: tree(values.rootHead),
     values,
   };
+}
+
+function directManifestChanges(
+  manifest,
+  {
+    baseVersion = "^4.120.0",
+    headVersion = "4.123.0",
+    baseScope = "development",
+    headScope = baseScope,
+  } = {},
+) {
+  const added = dependencyChange("added", "wrangler", headVersion);
+  added.manifest = manifest;
+  added.scope = headScope;
+  added.license = "MIT OR Apache-2.0";
+  added.source_repository_url = "https://github.com/cloudflare/workers-sdk";
+  const removed = dependencyChange("removed", "wrangler", baseVersion);
+  removed.manifest = manifest;
+  removed.scope = baseScope;
+  removed.package_url = "pkg:npm/wrangler";
+  removed.license = null;
+  return [added, removed];
+}
+
+function reviewedDirectManifestFixtures(
+  packagePath,
+  {
+    baseSection = "devDependencies",
+    headSection = baseSection,
+    baseVersion = "^4.120.0",
+    headVersion = "4.123.0",
+  } = {},
+) {
+  const rootStable = { name: "root-test", version: "1.0.0" };
+  const frontendStable = { name: "frontend-test", version: "1.0.0" };
+  const withWrangler = (value, section, version) => ({
+    ...structuredClone(value),
+    [section]: { wrangler: version },
+  });
+  const rootBase =
+    packagePath === "package.json"
+      ? withWrangler(rootStable, baseSection, baseVersion)
+      : rootStable;
+  const rootHead =
+    packagePath === "package.json"
+      ? withWrangler(rootStable, headSection, headVersion)
+      : rootStable;
+  const frontendBase =
+    packagePath === "astrologo-frontend/package.json"
+      ? withWrangler(frontendStable, baseSection, baseVersion)
+      : frontendStable;
+  const frontendHead =
+    packagePath === "astrologo-frontend/package.json"
+      ? withWrangler(frontendStable, headSection, headVersion)
+      : frontendStable;
+  const placementBySection = {
+    dependencies: {},
+    devDependencies: { dev: true },
+    optionalDependencies: { optional: true },
+    peerDependencies: { peer: true },
+  };
+  const lock = (packageJson, section) => ({
+    name: packageJson.name,
+    version: packageJson.version,
+    lockfileVersion: 3,
+    requires: true,
+    packages: {
+      "": structuredClone(packageJson),
+      ...(section === undefined
+        ? {}
+        : {
+            "node_modules/wrangler": registryDescriptor(
+              "wrangler",
+              "4.123.0",
+              8,
+              placementBySection[section],
+            ),
+          }),
+    },
+  });
+  const values = {
+    rootBasePackage: formattedJsonBlob(rootBase),
+    rootHeadPackage: formattedJsonBlob(rootHead),
+    rootBaseLock: formattedJsonBlob(
+      lock(rootBase, packagePath === "package.json" ? baseSection : undefined),
+    ),
+    rootHeadLock: formattedJsonBlob(
+      lock(rootHead, packagePath === "package.json" ? headSection : undefined),
+    ),
+    frontendBasePackage: formattedJsonBlob(frontendBase),
+    frontendHeadPackage: formattedJsonBlob(frontendHead),
+    frontendBaseLock: formattedJsonBlob(
+      lock(
+        frontendBase,
+        packagePath === "astrologo-frontend/package.json"
+          ? baseSection
+          : undefined,
+      ),
+    ),
+    frontendHeadLock: formattedJsonBlob(
+      lock(
+        frontendHead,
+        packagePath === "astrologo-frontend/package.json"
+          ? headSection
+          : undefined,
+      ),
+    ),
+  };
+  const tree = (phase) => ({
+    sha: phase === "base" ? SHA.baseTree : SHA.headTree,
+    truncated: false,
+    tree: [
+      blob(
+        "package.json",
+        values[`${phase === "base" ? "rootBase" : "rootHead"}Package`].oid,
+      ),
+      blob(
+        "package-lock.json",
+        values[`${phase === "base" ? "rootBase" : "rootHead"}Lock`].oid,
+      ),
+      blob(
+        "astrologo-frontend/package.json",
+        values[`${phase === "base" ? "frontendBase" : "frontendHead"}Package`]
+          .oid,
+      ),
+      blob(
+        "astrologo-frontend/package-lock.json",
+        values[`${phase === "base" ? "frontendBase" : "frontendHead"}Lock`].oid,
+      ),
+    ],
+  });
+  return { baseTree: tree("base"), headTree: tree("head"), values };
 }
 
 function reviewedLockCase(basePackages, headPackages) {
@@ -1916,6 +2049,128 @@ test("npm lock changes match Dependency Review and official registry metadata", 
   assert.notDeepEqual(tampered, tamperedBlob.response);
 });
 
+test("direct npm manifests match exact dependency section deltas in both projects", async () => {
+  const { expected } = expectedPullRequest();
+  const run = ({
+    manifest,
+    fixtureOptions,
+    comparison = directManifestChanges(manifest),
+  }) => {
+    const fixture = reviewedDirectManifestFixtures(manifest, fixtureOptions);
+    const responses = new Map(
+      Object.values(fixture.values).map((value) => [value.oid, value.response]),
+    );
+    return assertReviewedNpmLocks({
+      expected,
+      baseTree: fixture.baseTree,
+      headTree: fixture.headTree,
+      comparison,
+      api: async (path) => {
+        const response = responses.get(path.split("/").at(-1));
+        assert.notEqual(response, undefined, `unexpected npm blob ${path}`);
+        return structuredClone(response);
+      },
+      fetchImplementation: async () =>
+        assert.fail("stable lock entries must not query the npm registry"),
+    });
+  };
+
+  for (const manifest of ["package.json", "astrologo-frontend/package.json"]) {
+    await assert.doesNotReject(run({ manifest }));
+  }
+
+  const manifest = "astrologo-frontend/package.json";
+  for (const [section, scope] of [
+    ["dependencies", "runtime"],
+    ["devDependencies", "development"],
+    ["optionalDependencies", "runtime"],
+    ["peerDependencies", "runtime"],
+  ]) {
+    await assert.doesNotReject(
+      run({
+        manifest,
+        fixtureOptions: { baseSection: section, headSection: section },
+        comparison: directManifestChanges(manifest, {
+          baseScope: scope,
+          headScope: scope,
+        }),
+      }),
+    );
+  }
+  await assert.rejects(
+    run({
+      manifest,
+      fixtureOptions: {
+        baseSection: "dependencies",
+        headSection: "optionalDependencies",
+        baseVersion: "4.123.0",
+        headVersion: "4.123.0",
+      },
+      comparison: [],
+    }),
+    /section changes require a trusted lockfile rotation/,
+  );
+  await assert.rejects(
+    run({
+      manifest,
+      fixtureOptions: {
+        baseSection: "dependencies",
+        headSection: "optionalDependencies",
+        baseVersion: "^4.120.0",
+        headVersion: "4.123.0",
+      },
+      comparison: directManifestChanges(manifest, {
+        baseScope: "runtime",
+        headScope: "runtime",
+      }),
+    }),
+    /section changes require a trusted lockfile rotation/,
+  );
+  await assert.rejects(
+    run({
+      manifest,
+      fixtureOptions: {
+        baseSection: "devDependencies",
+        headSection: "dependencies",
+        baseVersion: "4.123.0",
+        headVersion: "4.123.0",
+      },
+      comparison: directManifestChanges(manifest, {
+        baseVersion: "4.123.0",
+        headVersion: "4.123.0",
+        baseScope: "development",
+        headScope: "runtime",
+      }),
+    }),
+    /section changes require a trusted lockfile rotation/,
+  );
+
+  const valid = directManifestChanges(manifest);
+  await assert.rejects(
+    run({ manifest, comparison: valid.slice(0, 1) }),
+    /direct dependency changes must match package.json/,
+  );
+  const divergent = structuredClone(valid);
+  divergent[0].scope = "runtime";
+  await assert.rejects(
+    run({ manifest, comparison: divergent }),
+    /direct dependency changes must match package.json/,
+  );
+  await assert.rejects(
+    run({
+      manifest,
+      comparison: [
+        ...valid,
+        {
+          ...dependencyChange("added", "unreviewed-extra", "1.0.0"),
+          manifest,
+        },
+      ],
+    }),
+    /direct dependency changes must match package.json/,
+  );
+});
+
 test("npm lock topology, bundled payloads and every occurrence fail closed", async () => {
   const { expected } = expectedPullRequest();
   const run = ({ fixture, comparison, registry = new Map() }) => {
@@ -2154,10 +2409,24 @@ test("dependency pagination accepts the live 2/18/2 response shape", async () =>
 });
 
 test("dependency comparison rejects total change overflow", async () => {
-  const overflow = Array.from({ length: 5_001 }, () => DEPENDENCY_CHANGES[0]);
+  const overflow = Array.from(
+    { length: MAX_DEPENDENCY_CHANGES + 1 },
+    () => DEPENDENCY_CHANGES[0],
+  );
   await assert.rejects(
     dependencyReviewRun([dependencyResponse(overflow)], []),
     /dependency comparison exceeded the reviewed total change limit/,
+  );
+});
+
+test("dependency review action output rejects total change overflow", async () => {
+  const overflow = Array.from(
+    { length: MAX_DEPENDENCY_CHANGES + 1 },
+    () => DEPENDENCY_CHANGES[0],
+  );
+  await assert.rejects(
+    dependencyReviewRun([], overflow),
+    /dependency review action output exceeded the reviewed total change limit/,
   );
 });
 


### PR DESCRIPTION
## Motivo

Follow-up mínimo da raiz confiável após o #296. O snapshot real do #294 expôs dois contratos ausentes:

- o Dependency Review retorna mudanças diretas em `package.json` e `astrologo-frontend/package.json`, além dos lockfiles;
- o limite total de 5.000 mudanças precisava de regressão discriminante também sobre a saída da action, não só sobre as páginas REST.

O mapa também pré-autoriza o blob revisado do teste de permissões do Scorecard (`61d44c38f1f813db8eab6927e2f9f9ea1288e415`), que impede comentário isolado de ocultar grant posterior.

## Delta confiável

Somente dois arquivos:

- `.github/scripts/trusted-dependency-review.mjs`
- `.github/scripts/trusted-dependency-review.test.mjs`

Commit direto `a0399094770ad61f37cd3f5371bf7a4c30a673d1`, assinado, pai exato `6876842c00b5b533158de18da0ae33e4631dd381` e trailer `Trusted-Dependency-Review-Root-Rotation: astrologo-app/v1`.

## Evidência focada

- mudanças npm diretas legítimas aceitas nos dois manifests;
- mudança ausente, divergente ou extra rejeitada;
- matriz das quatro seções: dependencies/runtime, devDependencies/development, optionalDependencies/runtime e peerDependencies/runtime;
- qualquer migração entre seções é rejeitada antes do lock e exige rotação confiável separada; o lock realista mantém sua validação estrita;
- saída da action com 5.001 registros rejeitada pelo limite compartilhado;
- `node --check`, Prettier e `git diff --check` verdes;
- Ultrabrain validou a política fail-closed; o Cross Review não avançou além do evidence-preflight porque os nomes dos manifests foram tratados como artefatos não anexados.

Os findings dos bots nos heads anteriores foram tratados no mesmo commit direto. Não foi criado suporte parcial aos flags contextuais de placement do lockfile v3.

Refs: #278, #294, #296.

— Codex
