### PR TITLE
fix(ci): bind permission maps to workflow jobs

### DIFF
--- a/.github/scripts/trusted-dependency-review.mjs
+++ b/.github/scripts/trusted-dependency-review.mjs
@@ -153,7 +153,7 @@ const LEAST_PRIVILEGE_ROLLOUT = [
   [
     ".github/scripts/scorecard-workflow.test.mjs",
     "5237744f213ad3908851a96101e042bce898ca9a",
-    "61d44c38f1f813db8eab6927e2f9f9ea1288e415",
+    "d3e564b9f2002d9322699e3dfa3f1ebbcd625037",
   ],
   [
     ".github/zizmor.yml",

--- a/.github/scripts/trusted-dependency-review.test.mjs
+++ b/.github/scripts/trusted-dependency-review.test.mjs
@@ -92,7 +92,7 @@ const LEAST_PRIVILEGE_ROLLOUT_TRANSITIONS = [
   [
     ".github/scripts/scorecard-workflow.test.mjs",
     "5237744f213ad3908851a96101e042bce898ca9a",
-    "61d44c38f1f813db8eab6927e2f9f9ea1288e415",
+    "d3e564b9f2002d9322699e3dfa3f1ebbcd625037",
   ],
   [
     ".github/zizmor.yml",


### PR DESCRIPTION
## Contexto

Uma revisão exact-head do #294 identificou que o teste de menor privilégio comparava os blocos de `permissions` como um multiconjunto global. Assim, trocar os grants entre jobs distintos ainda poderia passar.

## Mudança

- atualiza somente o `afterOid` revisado de `.github/scripts/scorecard-workflow.test.mjs` no scanner confiável;
- atualiza a mesma âncora na fixture do scanner;
- autoriza o blob `d3e564b9f2002d9322699e3dfa3f1ebbcd625037`, agora publicado e revisável no head `319fae416e062fa401810663d7692033661eeff8` do #294; o contrato preserva o owner (`workflow` ou `job:<id>`) de cada bloco e rejeita a troca entre os jobs Pages build/deploy.

O delta desta rotação contém exatamente duas linhas em dois arquivos. O commit é filho direto de `d7b8ba3f35967073af0e21889bea61f2e9101eb7`, assinado e verificado, com o trailer confiável exigido.

## Evidência local focada

- regressões de rollout e fases estáveis: 2/2;
- `node --check` nos dois scripts;
- Prettier e `git diff --check` verdes.

A validação autoritativa permanece no CI e nos revisores do head exato desta PR.

Refs #278, #294 e #297.

— Codex