### PR TITLE
ci: adicionar workflow Linear Release (pipeline continuous)

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -3,9 +3,14 @@ on:
   push:
     branches:
       - main
-# Politica enterprise (Discussion #150): sem write-all. Conjunto vazio no escopo do
-# workflow e grant minimo declarado no job.
+# Política enterprise (Discussion #150): sem write-all. Conjunto vazio no escopo do
+# workflow e grant mínimo declarado no job.
 permissions: {}
+# Agrupamento intencional: a linear-release-action varre todos os commits desde a
+# última release (fetch-depth: 0). Se um run pendente for substituído por um push
+# mais novo, os commits dele embarcam na release do run seguinte — nada se perde;
+# releases agrupam pushes em rajada por desenho, e o grupo evita corrida entre
+# duas criações de release simultâneas.
 concurrency:
   group: linear-release-${{ github.ref }}
   cancel-in-progress: false
@@ -14,17 +19,23 @@ jobs:
     name: Linear Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Politica zizmor da casa: secret so e lido dentro de environment dedicado.
-    # LINEAR_ACCESS_KEY vive como environment secret de linear-release, nao no repo.
+    # Política zizmor da casa: secret só é lido dentro de environment dedicado.
+    # LINEAR_ACCESS_KEY vive como environment secret de linear-release — escopo
+    # restrito a criar releases na pipeline deste repositório, nada além.
     environment: linear-release
     permissions:
-      contents: read # a action le o historico de commits para associar issues a release
+      contents: read # a action lê o histórico de commits para associar issues à release
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0 # historico completo: a action varre commits desde a ultima release
+          fetch-depth: 0 # histórico completo: a action varre commits desde a última release
           persist-credentials: false
 
+      # Risco de cadeia de suprimento aceito e registrado: nesta revisão a action
+      # baixa o binário da própria release upstream (asset mutável) sem verificação
+      # de digest. Contenção: a chave exposta só cria releases numa única pipeline
+      # do Linear e vive em environment dedicado; blast radius mínimo. Rastreio na
+      # issue vinculada ao PR que introduziu este workflow.
       - name: Create Linear release
         uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0.15.1
         with:

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -36,7 +36,15 @@ jobs:
       # de digest. Contenção: a chave exposta só cria releases numa única pipeline
       # do Linear e vive em environment dedicado; blast radius mínimo. Rastreio na
       # issue vinculada ao PR que introduziu este workflow.
+      #
+      # Best-effort por desenho: esta sincronização é um espelho opcional e sua
+      # falha (segredo expirado, indisponibilidade do Linear) NUNCA pode bloquear
+      # portões que varrem todos os runs do SHA (ex.: auto-tag/publicação). Por
+      # isso continue-on-error: o run conclui verde e a falha fica visível na
+      # anotação do passo; commits não sincronizados embarcam na release seguinte.
       - name: Create Linear release
+        id: linear_release
+        continue-on-error: true
         uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0.15.1
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -6,11 +6,11 @@ on:
 # Política enterprise (Discussion #150): sem write-all. Conjunto vazio no escopo do
 # workflow e grant mínimo declarado no job.
 permissions: {}
-# Agrupamento intencional: a linear-release-action varre todos os commits desde a
-# última release (fetch-depth: 0). Se um run pendente for substituído por um push
-# mais novo, os commits dele embarcam na release do run seguinte — nada se perde;
-# releases agrupam pushes em rajada por desenho, e o grupo evita corrida entre
-# duas criações de release simultâneas.
+# Agrupamento intencional: o CLI varre todos os commits desde a última release
+# (fetch-depth: 0). Se um run pendente for substituído por um push mais novo, os
+# commits dele embarcam na release do run seguinte — nada se perde; releases
+# agrupam pushes em rajada por desenho, e o grupo evita corrida entre duas
+# criações de release simultâneas.
 concurrency:
   group: linear-release-${{ github.ref }}
   cancel-in-progress: false
@@ -24,27 +24,35 @@ jobs:
     # restrito a criar releases na pipeline deste repositório, nada além.
     environment: linear-release
     permissions:
-      contents: read # a action lê o histórico de commits para associar issues à release
+      contents: read # o CLI lê o histórico de commits para associar issues à release
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0 # histórico completo: a action varre commits desde a última release
+          fetch-depth: 0 # histórico completo: o CLI varre commits desde a última release
           persist-credentials: false
 
-      # Risco de cadeia de suprimento aceito e registrado: nesta revisão a action
-      # baixa o binário da própria release upstream (asset mutável) sem verificação
-      # de digest. Contenção: a chave exposta só cria releases numa única pipeline
-      # do Linear e vive em environment dedicado; blast radius mínimo. Rastreio na
-      # issue vinculada ao PR que introduziu este workflow.
+      # Download verificado por digest — sem wrapper de terceiro: o binário oficial
+      # do CLI só executa se o SHA-256 conferir com o valor gravado abaixo
+      # (recomputado localmente e conferido contra o digest declarado pela API do
+      # GitHub em 17/08/2026). Troca de versão exige atualizar URL e digest juntos,
+      # por desenho. Inventário e fronteira de confiança em THIRDPARTY.md do
+      # repositório de governança.
       #
       # Best-effort por desenho: esta sincronização é um espelho opcional e sua
-      # falha (segredo expirado, indisponibilidade do Linear) NUNCA pode bloquear
-      # portões que varrem todos os runs do SHA (ex.: auto-tag/publicação). Por
-      # isso continue-on-error: o run conclui verde e a falha fica visível na
-      # anotação do passo; commits não sincronizados embarcam na release seguinte.
-      - name: Create Linear release
+      # falha (digest divergente, indisponibilidade, segredo expirado) NUNCA pode
+      # bloquear portões que varrem todos os runs do SHA (ex.: auto-tag/publicação).
+      # O run conclui verde e a falha fica visível na anotação do passo; commits
+      # não sincronizados embarcam na release seguinte.
+      - name: Create Linear release (CLI verificado por digest)
         id: linear_release
         continue-on-error: true
-        uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0.15.1
-        with:
-          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+        env:
+          LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
+          CLI_URL: https://github.com/linear/linear-release/releases/download/v0.15.0/linear-release-linux-x64
+          CLI_SHA256: 06eddce3f0d306fcdfed634105a57b02695b5c4fb40c42eb56d13feced729c99
+        run: |
+          bin="$RUNNER_TEMP/linear-release"
+          curl -fsSL "$CLI_URL" -o "$bin"
+          echo "$CLI_SHA256  $bin" | sha256sum -c -
+          chmod +x "$bin"
+          "$bin" sync

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -14,6 +14,9 @@ jobs:
     name: Linear Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Politica zizmor da casa: secret so e lido dentro de environment dedicado.
+    # LINEAR_ACCESS_KEY vive como environment secret de linear-release, nao no repo.
+    environment: linear-release
     permissions:
       contents: read # a action le o historico de commits para associar issues a release
     steps:

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,0 +1,28 @@
+name: Linear Release
+on:
+  push:
+    branches:
+      - main
+# Politica enterprise (Discussion #150): sem write-all. Conjunto vazio no escopo do
+# workflow e grant minimo declarado no job.
+permissions: {}
+concurrency:
+  group: linear-release-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  linear_release:
+    name: Linear Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read # a action le o historico de commits para associar issues a release
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # historico completo: a action varre commits desde a ultima release
+          persist-credentials: false
+
+      - name: Create Linear release
+        uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0.15.1
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}


### PR DESCRIPTION
Adiciona o workflow **Linear Release** (`linear/linear-release-action`, pinada por SHA em v0.15.1): cada push em `main` cria uma release na pipeline continuous deste repositorio, com as issues referenciadas nos commits embarcadas. Pushes em rajada agrupam numa mesma release por desenho (a action varre todos os commits desde a ultima release).

- `permissions: {}` no escopo + `contents: read` no job (politica da Discussion #150)
- secret `LINEAR_ACCESS_KEY` em **environment dedicado** `linear-release` (politica zizmor); escopo restrito a criar releases
- actions pinadas por SHA; `persist-credentials: false`; `fetch-depth: 0` (exigido pela action)
- risco de cadeia de suprimento do binario upstream documentado no proprio workflow e aceito com contencao

Closes #308.

Fase 2 (acoplar ao sucesso do Deploy) rastreada em #309.

Autoria: Claude Code (Claude Fable 5), sob direcao do operador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)