### PR TITLE
docs: plano do grau mundano SUPERADO pela entrega v02.21.00 (#276)

### DIFF
--- a/docs/PLANO_ITEM_2_GRAU_DENTRO_DA_CASA_PLACIDUS.md
+++ b/docs/PLANO_ITEM_2_GRAU_DENTRO_DA_CASA_PLACIDUS.md
@@ -1,5 +1,16 @@
 # Plano do item 2 — grau dentro da Casa Placidus
 
+> **⛔ SUPERADO (18/08/2026).** A substância deste plano foi entregue na
+> v02.21.00 (12/07/2026) por uma arquitetura diferente da proposta abaixo: o
+> grau mundano derivado do `swe_house_pos` vive no suplemento
+> `natalChartAnalysisV1` (`rawSwissHousePosition`, `degreeWithinHouseDeg`,
+> `mundaneLongitudeDeg`), persistido à parte e exposto no painel, no e-mail, no
+> prompt de IA e na ajuda contextual, com "indisponível" para mapas antigos —
+> sem evoluir o `housePlacement` do payload posicional `2.0.0` para `2.1.0`
+> como este plano propunha. O contrato abaixo permanece apenas como registro
+> histórico; reintroduzir o grau dentro do próprio `dados_posicionais_v2` seria
+> decisão nova, fora deste plano. Rastreio: issue #276.
+
 ## Objetivo
 
 Acrescentar, em uma segunda entrega, a coordenada fracionária que indica quanto o planeta avançou dentro de sua Casa Placidus. A primeira entrega já calcula as 12 cúspides e a casa de cada planeta; o item 2 preservará esse resultado e passará a expor também o “grau mundano” da casa com semântica inequívoca.


### PR DESCRIPTION
Closes #276
Fixes ASTROLO-1

Triagem profunda de 18/08 (veredito na issue): a substancia do item 2 — grau mundano da Casa Placidus com semantica inequivoca, derivado do hpos bruto do swe_house_pos — foi entregue na v02.21.00 (12/07/2026, commit d93a34c) via suplemento natalChartAnalysisV1 (rawSwissHousePosition, degreeWithinHouseDeg, mundaneLongitudeDeg), exposto no painel, no e-mail, no prompt de IA e na ajuda contextual, com ''indisponivel'' para mapas antigos. A embalagem proposta pelo plano (evoluir housePlacement do payload posicional 2.0.0 para 2.1.0) foi superada por essa arquitetura. Este PR aplica a disciplina de documento-fantasma: banner SUPERADO no plano, no MESMO ato que fecha a issue.

Gates raiz verdes no HEAD deste PR (eslint + prettier publico).

— Claude Code (Claude Fable 5)