### PR TITLE
docs: clarify legacy mundane degree behavior

### DIFF
--- a/astrologo-frontend/src/infoContent.test.ts
+++ b/astrologo-frontend/src/infoContent.test.ts
@@ -124,12 +124,15 @@ describe('conteúdo leigo dos botões Saiba mais', () => {
     expect(text).not.toContain('perfil metodológico versionado');
   });
 
-  it('distingue casa, cúspide e grau mundano', () => {
+  it('distingue casa, cúspide, artefato natal ausente e grau mundano indisponível', () => {
     const text = flatten('houseInfluences');
     expect(text).toContain('grau mundano');
     expect(text).not.toContain('swe_house_pos');
     expect(text).toMatch(/não é estimad[oa] pelo tamanho do arco/iu);
-    expect(text).toContain('indisponível');
+    expect(text).toContain('Mapas antigos podem não ter esse dado');
+    expect(text).toContain('não é exibido nem estimado');
+    expect(text).toContain('Quando o mapa possui a análise das casas');
+    expect(text).toContain('aparece como indisponível');
   });
 
   it('explica céu atual e trânsitos sem prometer acontecimentos', () => {

--- a/astrologo-frontend/src/infoContent.ts
+++ b/astrologo-frontend/src/infoContent.ts
@@ -377,7 +377,7 @@ const houseInfluencesContent: InfoContent = {
       items: [
         'O grau no signo vem da longitude tropical. O grau da cúspide marca o começo zodiacal de uma casa. O grau mundano indica o avanço do corpo dentro da divisão Placidus e usa uma escala própria de 0 a menos de 30 graus.',
         'A posição proporcional dentro da casa vem do mesmo cálculo das Casas Placidus. Ela não é estimada pelo tamanho do arco entre duas cúspides, porque essa aproximação confundiria referências diferentes.',
-        'Mapas antigos não guardam o valor fracionário. Neles, ou quando Placidus não pode ser calculado com segurança, o grau mundano aparece como indisponível em vez de ser inventado.',
+        'Mapas antigos podem não ter esse dado. Nesses casos, o grau mundano não é exibido nem estimado. Quando o mapa possui a análise das casas, mas o motor não pode calcular a posição com segurança, o grau mundano aparece como indisponível em vez de ser inventado.',
       ],
     },
     {

--- a/docs/PLANO_ITEM_2_GRAU_DENTRO_DA_CASA_PLACIDUS.md
+++ b/docs/PLANO_ITEM_2_GRAU_DENTRO_DA_CASA_PLACIDUS.md
@@ -4,12 +4,15 @@
 > v02.21.00 (12/07/2026) por uma arquitetura diferente da proposta abaixo: o
 > grau mundano derivado do `swe_house_pos` vive no suplemento
 > `natalChartAnalysisV1` (`rawSwissHousePosition`, `degreeWithinHouseDeg`,
-> `mundaneLongitudeDeg`), persistido à parte e exposto no painel, no e-mail, no
-> prompt de IA e na ajuda contextual, com "indisponível" para mapas antigos —
-> sem evoluir o `housePlacement` do payload posicional `2.0.0` para `2.1.0`
-> como este plano propunha. O contrato abaixo permanece apenas como registro
-> histórico; reintroduzir o grau dentro do próprio `dados_posicionais_v2` seria
-> decisão nova, fora deste plano. Rastreio: issue #276.
+> `mundaneLongitudeDeg`), persistido à parte e, quando o suplemento existe,
+> exposto no painel, no e-mail, no prompt de IA e na ajuda contextual. Mapas
+> anteriores sem esse suplemento continuam legíveis pelo `dadosPosicionaisV2`,
+> mas não exibem nem estimam o grau mundano; o rótulo "indisponível" só aparece
+> quando um suplemento presente registra o campo como `unavailable` — sem evoluir
+> o `housePlacement` do payload posicional `2.0.0` para `2.1.0` como este plano
+> propunha. O contrato abaixo permanece apenas como registro histórico;
+> reintroduzir o grau dentro do próprio `dados_posicionais_v2` seria decisão nova,
+> fora deste plano. Rastreio: issue #276.
 
 ## Objetivo
 


### PR DESCRIPTION
## O que mudou

* corrige a afirmação de que todo mapa antigo mostraria o grau mundano como "indisponível";
* distingue artefato `natalChartAnalysisV1` ausente de um suplemento presente com campo `unavailable`;
* mantém o comportamento seguro: nenhum grau é estimado ou inventado;
* fortalece o teste da ajuda contextual.

## Causa

O review Codex do PR LCV-Ideas-Software/astrologo-app#314 chegou após o merge e mostrou que a documentação prometia um fallback que o runtime deliberadamente não implementa. Mapas antigos sem o suplemento continuam legíveis, mas não exibem o grau mundano.

## Validação

* teste focado: 14/14;
* suíte frontend: 58 arquivos, 347 testes;
* lint e Biome, raiz e frontend;
* build Vite;
* build Pages Functions;
* `git diff --check`;
* Ultrabrain: sem lacunas;
* Cross Review: nenhum peer chamado porque o preflight projetou US$ 33,76, acima do teto de US$ 5.

Closes LCV-Ideas-Software/astrologo-app#276<br>Fixes LCV-Ideas-Software/astrologo-app#276

Review original: https://github.com/LCV-Ideas-Software/astrologo-app/pull/314#discussion_r3805030109