### PR TITLE
fix(ci): restaurar gate Zizmor no merge group

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
 
 permissions: {}
 


### PR DESCRIPTION
## Resultado

Restaura o evento `merge_group` no workflow Zizmor para que a fila nativa produza o contexto `Run zizmor` no SHA sintético.

O ruleset existente `main: native merge queue` já recebeu, sem bypass e sem alterar a fila, os quatro contextos previamente comprovados:

- `Analyze actions`
- `Analyze javascript-typescript`
- `Dependency Review`
- `Build Pages artifact`

Depois que este PR provar `Run zizmor` no próprio `merge_group`, esse contexto será acrescentado como quinto check obrigatório.

## Causa raiz

O PR #306 trocou o workflow reutilizável pelo action direto e removeu acidentalmente o gatilho `merge_group`. Ao mesmo tempo, o ruleset do repositório permaneceu apenas com `merge_queue`, sem `required_status_checks`, fazendo o controlador central falhar no preflight.

## Validação

- `git diff --check`
- `actionlint .github/workflows/zizmor.yml`
- commit GPG assinado
- readback do ruleset: `SQUASH`, `ALLGREEN`, lote 1, quatro checks GitHub Actions, zero bypass

Closes #324
Relates to LCV-Ideas-Software/github-operations#82