### PR TITLE
ci: usar action oficial da Linear Release v0.16.0

### DIFF
--- a/.github/workflows/actions.lock
+++ b/.github/workflows/actions.lock
@@ -15,6 +15,7 @@ workflows:
         - 'cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0'
     '.github/workflows/linear-release.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
+        - 'linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205'
     '.github/workflows/pages.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
         - 'actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d'
@@ -87,6 +88,11 @@ dependencies:
         commit: 'sha1-ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd'
         owner_id: 9919
         repo_id: 259445878
+    'linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205':
+        ref: 'v0.16.0'
+        commit: 'sha1-0a25abab892a91062ebf42260dbb2ce6277aa205'
+        owner_id: 46686594
+        repo_id: 1150447766
     'ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc':
         ref: 'v2.4.4'
         commit: 'sha1-2d1146689b8cda280b9bc96326124645441f03bc'

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -53,28 +53,21 @@ jobs:
           fetch-depth: 0 # histórico completo: o CLI varre commits desde a última release
           persist-credentials: false
 
-      # Download verificado por digest — sem wrapper de terceiro: o binário oficial
-      # do CLI só executa se o SHA-256 conferir com o valor gravado abaixo
-      # (recomputado localmente e conferido contra o digest declarado pela API do
-      # GitHub em 17/08/2026). Troca de versão exige atualizar URL e digest juntos,
-      # por desenho. Inventário e fronteira de confiança em THIRDPARTY.md do
-      # repositório de governança.
+      # Integração oficial da Linear, pinada no commit da release v0.16.0 e com a
+      # versão do CLI também explícita. O pin protege o código da action contra
+      # deslocamento de tag; o instalador upstream ainda não verifica o digest do
+      # asset do CLI, risco residual registrado em ASTROLO-15 e
+      # linear/linear-release-action#59.
       #
       # Best-effort por desenho: esta sincronização é um espelho opcional e sua
-      # falha (digest divergente, indisponibilidade, segredo expirado) NUNCA pode
+      # falha (indisponibilidade, segredo expirado ou erro upstream) NUNCA pode
       # bloquear portões que varrem todos os runs do SHA. O run conclui verde e a
       # falha fica visível na anotação do passo; commits não sincronizados embarcam
       # na release seguinte.
-      - name: Create Linear release (CLI verificado por digest)
+      - name: Create Linear release (action oficial)
         id: linear_release
         continue-on-error: true
-        env:
-          LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
-          CLI_URL: https://github.com/linear/linear-release/releases/download/v0.15.0/linear-release-linux-x64
-          CLI_SHA256: 06eddce3f0d306fcdfed634105a57b02695b5c4fb40c42eb56d13feced729c99
-        run: |
-          bin="$RUNNER_TEMP/linear-release"
-          curl -fsSL "$CLI_URL" -o "$bin"
-          echo "$CLI_SHA256  $bin" | sha256sum -c -
-          chmod +x "$bin"
-          "$bin" sync
+        uses: linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205 # v0.16.0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          cli_version: v0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Alterado
 
+- A criação de Linear Releases após deploy bem-sucedido passa a usar a action oficial `linear/linear-release-action` v0.16.0, pinada por SHA completo; o gatilho pós-Deploy, o SHA publicado, o histórico Git completo, o environment dedicado e as permissões mínimas permanecem inalterados.
 - CodeQL, Dependency Review, OpenSSF Scorecard e Zizmor passam a usar diretamente as implementacoes oficiais, sem gate SARIF, reusable workflow, manifesto, scanner ou validador proprio.
 - O deploy passa a usar `cloudflare/wrangler-action` oficial; o identificador da D1 compartilhada fica versionado no `wrangler.json`, enquanto tokens e credenciais permanecem secretos.
 - O Auto-add nativo dos Projects #11 e #17 substitui o workflow com GitHub App e seu verificador.


### PR DESCRIPTION
## Resultado

Substitui o download customizado do Linear Release CLI pela action oficial `linear/linear-release-action` v0.16.0, pinada no SHA completo e assinado `0a25abab892a91062ebf42260dbb2ce6277aa205`.

Preserva sem alteração:

- disparo somente após `Deploy` bem-sucedido em `main`;
- checkout do SHA exato publicado;
- histórico completo (`fetch-depth: 0`);
- `persist-credentials: false`;
- environment `linear-release` e `contents: read`;
- concorrência fail-safe e contrato best-effort.

O deploy Cloudflare já usa a action oficial Wrangler e não foi alterado. Não há envio direto ao Slack neste repositório.

## Segurança e validação

- `git diff --check`: passou;
- `actionlint`: passou;
- `zizmor`: passou, sem achados;
- `gh actions-lock --verify`: passou;
- environment `linear-release`: contém exatamente o secret `LINEAR_ACCESS_KEY`;
- risco residual do instalador upstream sem digest permanece explicitamente rastreado em linear/linear-release-action#59.

## Tracking

Closes #326
Fixes ASTROLO-15

— Codex