### PR TITLE
docs(contacts): route conduct and support email (GIT-135)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -24,7 +24,7 @@ Reports of violations can be sent privately to:
 
 **conductcode@lcv.dev**
 
-This is the same private channel used for security reports (see [SECURITY.md](./SECURITY.md)). Reports will be acknowledged within 48 hours and handled per the Contributor Covenant 3.0 enforcement ladder.
+This address receives conduct reports only. Report security vulnerabilities separately through [SECURITY.md](./SECURITY.md) at **security@lcv.dev**. Conduct reports will be acknowledged within 48 hours and handled per the Contributor Covenant 3.0 enforcement ladder.
 
 All reporters will have their identity kept confidential.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,7 +22,7 @@ This applies to:
 
 Reports of violations can be sent privately to:
 
-**lcv@lcv.dev**
+**conductcode@lcv.dev**
 
 This is the same private channel used for security reports (see [SECURITY.md](./SECURITY.md)). Reports will be acknowledged within 48 hours and handled per the Contributor Covenant 3.0 enforcement ladder.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ By contributing, you agree your contribution is licensed under [AGPL-3.0-or-late
 
 ## Code of Conduct
 
-By participating, you agree to follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) (Contributor Covenant 3.0). Violations to `lcv@lcv.dev`.
+By participating, you agree to follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) (Contributor Covenant 3.0). Violations to `chamados@lcv.dev`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ By contributing, you agree your contribution is licensed under [AGPL-3.0-or-late
 
 ## Code of Conduct
 
-By participating, you agree to follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) (Contributor Covenant 3.0). Violations to `chamados@lcv.dev`.
+By participating, you agree to follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) (Contributor Covenant 3.0). General support: `chamados@lcv.dev`. Code of Conduct violations: `conductcode@lcv.dev`.
 
 ---
 


### PR DESCRIPTION
## Summary

- route conduct reports to `conductcode@lcv.dev`;
- route contributor support to `chamados@lcv.dev`.

## Validation

- `git diff --check` passed;
- changed files are exactly `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`;
- zero `lcv@lcv.dev` occurrences remain in the three target documents;
- test suites were not run because this is a documentation-only change, as directed by GIT-135.

Refs LCV-Ideas-Software/github-operations#151

Linear: [GIT-135](https://linear.app/lcv-ideas-software/issue/GIT-135/maintenance-padronizar-canais-de-conduta-e-chamados-na-frota)