### PR TITLE
ci(dependabot): enable repository-native auto-merge

### DIFF
--- a/.github/workflows/actions.lock
+++ b/.github/workflows/actions.lock
@@ -6,6 +6,8 @@ workflows:
     '.github/workflows/codeql.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
         - 'github/codeql-action@cdf488f595d80d6e07e03d4674febd5ab45fa938'
+    '.github/workflows/dependabot-automerge.yml':
+        - 'actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1'
     '.github/workflows/dependency-review.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
         - 'actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294'
@@ -41,6 +43,11 @@ dependencies:
         commit: 'sha1-45bfe0192ca1faeb007ade9deae92b16b8254a0d'
         owner_id: 44036562
         repo_id: 513659658
+    'actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1':
+        ref: 'v3.2.0'
+        commit: 'sha1-bcd2ba49218906704ab6c1aa796996da409d3eb1'
+        owner_id: 44036562
+        repo_id: 642580244
     'actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294':
         ref: 'v5.0.0'
         commit: 'sha1-a1d282b36b6f3519aa1f3fc636f609c47dddb294'

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,50 @@
+# This workflow is managed by gh actions-lock.
+
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+
+# The event token only reads the pull request; the short-lived App token performs the native merge action.
+permissions:
+  pull-requests: read # Read the triggering PR; native merge is performed with the scoped App token below.
+
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  enable: # zizmor: ignore[secrets-outside-env] Dependabot secrets cannot be environment-scoped; no PR code executes.
+    name: Enable native auto-merge
+    if: >-
+      github.event.pull_request.user.id == 49699333 &&
+      github.repository == github.event.pull_request.head.repo.full_name &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Create the repository-scoped GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.DEPENDABOT_AUTOMERGE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.DEPENDABOT_AUTOMERGE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-merge-queues: write
+
+      - name: Enable GitHub native auto-merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --match-head-commit "$HEAD_SHA" "$PR_URL"
+


### PR DESCRIPTION
## Summary

- replaces fleet-central admission with a repository-local Dependabot workflow
- authenticates through the GitHub-owned create-github-app-token action
- uses native auto-merge/merge queue with an exact-head guard
- updates the repository-local actions.lock with gh-actions-lock

Tracking: [GIT-140](https://linear.app/lcv-ideas-software/issue/GIT-140)

## Validation

- official gh actions-lock generation
- git diff --check
- GitHub required gates will validate this exact head