### PR TITLE
chore: update official security action pins (LCV-178)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,5 +60,5 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
           workingDirectory: astrologo-frontend
-          wranglerVersion: "4.127.1"
+          wranglerVersion: "4.128.0"
           command: pages deploy dist --project-name=astrologo-frontend --branch=main --commit-dirty=true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -46,6 +46,6 @@ jobs:
           retention-days: 5
 
       - name: Upload Scorecard results to code scanning
-        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        uses: github/codeql-action/upload-sarif@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -33,4 +33,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Corrigido
 
+- Sincronizadas as duas cópias do inventário de dependências diretas com os manifestos e lockfiles: `globals` 17.12.0 nos dois pacotes, `lucide-react` 1.39.0 e `@types/node` 26.4.1 no frontend. Os textos integrais das licenças permanecem inalterados.
+
 - Os dois arquivos de configuração ESLint definem `parserOptions.tsconfigRootDir` como `import.meta.dirname`, conforme a opção oficial do typescript-eslint. Isso elimina a ambiguidade entre raiz e frontend quando a CI executa o lint antes de instalar o segundo pacote npm, sem ignorar arquivos nem desativar regras (ASTROLO-18 / #373).
 
 ### Adicionado
@@ -18,7 +20,7 @@
 - O inventário acompanha as quatro atualizações de ferramentas do frontend (#364). A entrada do Wrangler acompanha a versão 4.128.0 fixada no lockfile; os textos MIT e Apache-2.0 do tag oficial são idênticos aos já preservados.
 - As cópias canônicas do inventário acompanham o `typescript-eslint` 8.69.0 do frontend, sem alterar as obrigações de licença (#370).
 - As cópias canônicas do inventário acompanham o `typescript-eslint` 8.69.0 do pacote raiz, sem alterar as obrigações de licença (#369).
-- O inventário preserva a atualização do `lucide-react` 1.38.0 já fixado no lockfile (#365); o teste customizado de inventário é aposentado nesta reforma.
+- O inventário preserva a atualização anterior do `lucide-react` (#365); o teste customizado de inventário é aposentado nesta reforma.
 - A reforma substitui os validadores customizados do inventário e do relatório de Functions. O `build.license` nativo do Vite continua gerando `legal/BUNDLED-LICENSES.md` para o navegador; os textos completos de `legal/FUNCTIONS-BUNDLED-LICENSES.md`, entregues anteriormente em #346, permanecem como snapshot mantido e distribuído com o aplicativo. O snapshot exige revisão quando as dependências de servidor mudarem e não comprova automaticamente a cobertura de versões futuras.
 - Linear Release usa a action e o CLI oficiais `v0.17.2`, com gatilho após Deploy de push bem-sucedido no mesmo repositório, SHA publicado exato, histórico Git completo, environment dedicado e permissões mínimas.
 - CodeQL usa Default setup; Dependency Review, OpenSSF Scorecard e Zizmor usam diretamente as implementações oficiais. Pages mantém seu artefato documental separado; CI e Deploy preservam lint raiz/frontend, Prettier HTML, Biome, testes e builds do navegador e de Functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 
 ### Alterado
 
-- O inventário acompanha as quatro atualizações de ferramentas do frontend; a referência jurídica do Wrangler 4.127.1 usa seu tag oficial, com textos MIT e Apache-2.0 idênticos aos já preservados (#364).
+- Atualizados os pins oficiais de CodeQL para 4.38.0 e zizmor-action para 0.6.4; o input do deploy usa o Wrangler 4.128.0 já fixado no lockfile.
+
+- O inventário acompanha as quatro atualizações de ferramentas do frontend (#364). A entrada do Wrangler acompanha a versão 4.128.0 fixada no lockfile; os textos MIT e Apache-2.0 do tag oficial são idênticos aos já preservados.
 - As cópias canônicas do inventário acompanham o `typescript-eslint` 8.69.0 do frontend, sem alterar as obrigações de licença (#370).
 - As cópias canônicas do inventário acompanham o `typescript-eslint` 8.69.0 do pacote raiz, sem alterar as obrigações de licença (#369).
 - O inventário preserva a atualização do `lucide-react` 1.38.0 já fixado no lockfile (#365); o teste customizado de inventário é aposentado nesta reforma.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ CI runs on PRs to `main` and manual dispatches with Node.js 24. It installs both
 npm roots with `npm ci`, then checks root ESLint/public HTML formatting and
 frontend ESLint, Biome, tests, Vite build and Wrangler Pages Functions build.
 Deploy repeats these checks on a push to `main` and publishes the application
-with the official Cloudflare Wrangler Action and Wrangler 4.127.1. The existing
+with the official Cloudflare Wrangler Action and Wrangler 4.128.0. The existing
 D1 binding, Swiss WASM preparation and application behavior remain unchanged.
 
 GitHub Pages serves the separate `site/` artifact, with a PR build and deployment

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -48,7 +48,7 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | astrologo-frontend/package.json | typescript-eslint | devDependencies | ^8.69.0 | 8.69.0 | MIT | https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz |
 | astrologo-frontend/package.json | vite | devDependencies | ^8.2.2 | 8.2.2 | MIT | https://registry.npmjs.org/vite/-/vite-8.2.2.tgz |
 | astrologo-frontend/package.json | vitest | devDependencies | ^4.1.11 | 4.1.11 | MIT | https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz |
-| astrologo-frontend/package.json | wrangler | devDependencies | 4.127.1 | 4.127.1 | MIT OR Apache-2.0 | https://registry.npmjs.org/wrangler/-/wrangler-4.127.1.tgz |
+| astrologo-frontend/package.json | wrangler | devDependencies | 4.128.0 | 4.128.0 | MIT OR Apache-2.0 | https://registry.npmjs.org/wrangler/-/wrangler-4.128.0.tgz |
 
 ## Textos das licenças dos bundles publicados
 

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -13,7 +13,7 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | package.json | eslint-config-prettier | devDependencies | ^10.1.8 | 10.1.8 | MIT | https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz |
 | package.json | eslint-plugin-react-hooks | devDependencies | ^7.1.1 | 7.1.1 | MIT | https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz |
 | package.json | eslint-plugin-react-refresh | devDependencies | ^0.5.5 | 0.5.5 | MIT | https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.5.tgz |
-| package.json | globals | devDependencies | ^17.11.0 | 17.11.0 | MIT | https://registry.npmjs.org/globals/-/globals-17.11.0.tgz |
+| package.json | globals | devDependencies | ^17.12.0 | 17.12.0 | MIT | https://registry.npmjs.org/globals/-/globals-17.12.0.tgz |
 | package.json | prettier | devDependencies | ^3.9.6 | 3.9.6 | MIT | https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz |
 | package.json | typescript-eslint | devDependencies | ^8.69.0 | 8.69.0 | MIT | https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz |
 | astrologo-frontend/package.json | @js-temporal/polyfill | dependencies | 0.5.1 | 0.5.1 | ISC | https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz |
@@ -21,7 +21,7 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | astrologo-frontend/package.json | astronomy-engine | dependencies | 2.1.19 | 2.1.19 | MIT | https://registry.npmjs.org/astronomy-engine/-/astronomy-engine-2.1.19.tgz |
 | astrologo-frontend/package.json | d3-geo | dependencies | 3.1.1 | 3.1.1 | ISC | https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz |
 | astrologo-frontend/package.json | dompurify | dependencies | ^3.4.14 | 3.4.14 | (MPL-2.0 OR Apache-2.0) | https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz |
-| astrologo-frontend/package.json | lucide-react | dependencies | ^1.38.0 | 1.38.0 | ISC | https://registry.npmjs.org/lucide-react/-/lucide-react-1.38.0.tgz |
+| astrologo-frontend/package.json | lucide-react | dependencies | ^1.39.0 | 1.39.0 | ISC | https://registry.npmjs.org/lucide-react/-/lucide-react-1.39.0.tgz |
 | astrologo-frontend/package.json | react | dependencies | ^19.2.8 | 19.2.8 | MIT | https://registry.npmjs.org/react/-/react-19.2.8.tgz |
 | astrologo-frontend/package.json | react-dom | dependencies | ^19.2.8 | 19.2.8 | MIT | https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz |
 | astrologo-frontend/package.json | sanitize-html | dependencies | ^2.17.7 | 2.17.7 | MIT | https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz |
@@ -32,7 +32,7 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | astrologo-frontend/package.json | @eslint/js | devDependencies | ^10.0.1 | 10.0.1 | MIT | https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz |
 | astrologo-frontend/package.json | @fusionstrings/swiss-eph | devDependencies | 0.1.1 | 0.1.1 | AGPL-3.0 | https://registry.npmjs.org/@fusionstrings/swiss-eph/-/swiss-eph-0.1.1.tgz |
 | astrologo-frontend/package.json | @types/d3-geo | devDependencies | 3.1.1 | 3.1.1 | MIT | https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz |
-| astrologo-frontend/package.json | @types/node | devDependencies | ^26.4.0 | 26.4.0 | MIT | https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz |
+| astrologo-frontend/package.json | @types/node | devDependencies | ^26.4.1 | 26.4.1 | MIT | https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz |
 | astrologo-frontend/package.json | @types/react | devDependencies | ^19.2.18 | 19.2.18 | MIT | https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz |
 | astrologo-frontend/package.json | @types/react-dom | devDependencies | ^19.2.5 | 19.2.5 | MIT | https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz |
 | astrologo-frontend/package.json | @types/sanitize-html | devDependencies | ^2.16.1 | 2.16.1 | MIT | https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz |
@@ -43,7 +43,7 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | astrologo-frontend/package.json | eslint-plugin-react-hooks | devDependencies | ^7.1.1 | 7.1.1 | MIT | https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz |
 | astrologo-frontend/package.json | eslint-plugin-react-refresh | devDependencies | ^0.5.5 | 0.5.5 | MIT | https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.5.tgz |
 | astrologo-frontend/package.json | fast-check | devDependencies | 4.9.0 | 4.9.0 | MIT | https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz |
-| astrologo-frontend/package.json | globals | devDependencies | ^17.11.0 | 17.11.0 | MIT | https://registry.npmjs.org/globals/-/globals-17.11.0.tgz |
+| astrologo-frontend/package.json | globals | devDependencies | ^17.12.0 | 17.12.0 | MIT | https://registry.npmjs.org/globals/-/globals-17.12.0.tgz |
 | astrologo-frontend/package.json | typescript | devDependencies | ~6.0.3 | 6.0.3 | Apache-2.0 | https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz |
 | astrologo-frontend/package.json | typescript-eslint | devDependencies | ^8.69.0 | 8.69.0 | MIT | https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz |
 | astrologo-frontend/package.json | vite | devDependencies | ^8.2.2 | 8.2.2 | MIT | https://registry.npmjs.org/vite/-/vite-8.2.2.tgz |

--- a/astrologo-frontend/public/legal/THIRDPARTY.md
+++ b/astrologo-frontend/public/legal/THIRDPARTY.md
@@ -48,7 +48,7 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | astrologo-frontend/package.json | typescript-eslint | devDependencies | ^8.69.0 | 8.69.0 | MIT | https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz |
 | astrologo-frontend/package.json | vite | devDependencies | ^8.2.2 | 8.2.2 | MIT | https://registry.npmjs.org/vite/-/vite-8.2.2.tgz |
 | astrologo-frontend/package.json | vitest | devDependencies | ^4.1.11 | 4.1.11 | MIT | https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz |
-| astrologo-frontend/package.json | wrangler | devDependencies | 4.127.1 | 4.127.1 | MIT OR Apache-2.0 | https://registry.npmjs.org/wrangler/-/wrangler-4.127.1.tgz |
+| astrologo-frontend/package.json | wrangler | devDependencies | 4.128.0 | 4.128.0 | MIT OR Apache-2.0 | https://registry.npmjs.org/wrangler/-/wrangler-4.128.0.tgz |
 
 ## Textos das licenças dos bundles publicados
 

--- a/astrologo-frontend/public/legal/THIRDPARTY.md
+++ b/astrologo-frontend/public/legal/THIRDPARTY.md
@@ -13,7 +13,7 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | package.json | eslint-config-prettier | devDependencies | ^10.1.8 | 10.1.8 | MIT | https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz |
 | package.json | eslint-plugin-react-hooks | devDependencies | ^7.1.1 | 7.1.1 | MIT | https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz |
 | package.json | eslint-plugin-react-refresh | devDependencies | ^0.5.5 | 0.5.5 | MIT | https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.5.tgz |
-| package.json | globals | devDependencies | ^17.11.0 | 17.11.0 | MIT | https://registry.npmjs.org/globals/-/globals-17.11.0.tgz |
+| package.json | globals | devDependencies | ^17.12.0 | 17.12.0 | MIT | https://registry.npmjs.org/globals/-/globals-17.12.0.tgz |
 | package.json | prettier | devDependencies | ^3.9.6 | 3.9.6 | MIT | https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz |
 | package.json | typescript-eslint | devDependencies | ^8.69.0 | 8.69.0 | MIT | https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz |
 | astrologo-frontend/package.json | @js-temporal/polyfill | dependencies | 0.5.1 | 0.5.1 | ISC | https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz |
@@ -21,7 +21,7 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | astrologo-frontend/package.json | astronomy-engine | dependencies | 2.1.19 | 2.1.19 | MIT | https://registry.npmjs.org/astronomy-engine/-/astronomy-engine-2.1.19.tgz |
 | astrologo-frontend/package.json | d3-geo | dependencies | 3.1.1 | 3.1.1 | ISC | https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz |
 | astrologo-frontend/package.json | dompurify | dependencies | ^3.4.14 | 3.4.14 | (MPL-2.0 OR Apache-2.0) | https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz |
-| astrologo-frontend/package.json | lucide-react | dependencies | ^1.38.0 | 1.38.0 | ISC | https://registry.npmjs.org/lucide-react/-/lucide-react-1.38.0.tgz |
+| astrologo-frontend/package.json | lucide-react | dependencies | ^1.39.0 | 1.39.0 | ISC | https://registry.npmjs.org/lucide-react/-/lucide-react-1.39.0.tgz |
 | astrologo-frontend/package.json | react | dependencies | ^19.2.8 | 19.2.8 | MIT | https://registry.npmjs.org/react/-/react-19.2.8.tgz |
 | astrologo-frontend/package.json | react-dom | dependencies | ^19.2.8 | 19.2.8 | MIT | https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz |
 | astrologo-frontend/package.json | sanitize-html | dependencies | ^2.17.7 | 2.17.7 | MIT | https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz |
@@ -32,7 +32,7 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | astrologo-frontend/package.json | @eslint/js | devDependencies | ^10.0.1 | 10.0.1 | MIT | https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz |
 | astrologo-frontend/package.json | @fusionstrings/swiss-eph | devDependencies | 0.1.1 | 0.1.1 | AGPL-3.0 | https://registry.npmjs.org/@fusionstrings/swiss-eph/-/swiss-eph-0.1.1.tgz |
 | astrologo-frontend/package.json | @types/d3-geo | devDependencies | 3.1.1 | 3.1.1 | MIT | https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz |
-| astrologo-frontend/package.json | @types/node | devDependencies | ^26.4.0 | 26.4.0 | MIT | https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz |
+| astrologo-frontend/package.json | @types/node | devDependencies | ^26.4.1 | 26.4.1 | MIT | https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz |
 | astrologo-frontend/package.json | @types/react | devDependencies | ^19.2.18 | 19.2.18 | MIT | https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz |
 | astrologo-frontend/package.json | @types/react-dom | devDependencies | ^19.2.5 | 19.2.5 | MIT | https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz |
 | astrologo-frontend/package.json | @types/sanitize-html | devDependencies | ^2.16.1 | 2.16.1 | MIT | https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz |
@@ -43,7 +43,7 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | astrologo-frontend/package.json | eslint-plugin-react-hooks | devDependencies | ^7.1.1 | 7.1.1 | MIT | https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz |
 | astrologo-frontend/package.json | eslint-plugin-react-refresh | devDependencies | ^0.5.5 | 0.5.5 | MIT | https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.5.tgz |
 | astrologo-frontend/package.json | fast-check | devDependencies | 4.9.0 | 4.9.0 | MIT | https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz |
-| astrologo-frontend/package.json | globals | devDependencies | ^17.11.0 | 17.11.0 | MIT | https://registry.npmjs.org/globals/-/globals-17.11.0.tgz |
+| astrologo-frontend/package.json | globals | devDependencies | ^17.12.0 | 17.12.0 | MIT | https://registry.npmjs.org/globals/-/globals-17.12.0.tgz |
 | astrologo-frontend/package.json | typescript | devDependencies | ~6.0.3 | 6.0.3 | Apache-2.0 | https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz |
 | astrologo-frontend/package.json | typescript-eslint | devDependencies | ^8.69.0 | 8.69.0 | MIT | https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz |
 | astrologo-frontend/package.json | vite | devDependencies | ^8.2.2 | 8.2.2 | MIT | https://registry.npmjs.org/vite/-/vite-8.2.2.tgz |


### PR DESCRIPTION
Os workflows e a documentação do deploy ainda referenciavam versões anteriores às releases oficiais e ao lockfile. Atualiza CodeQL para 4.38.0 e zizmor-action para 0.6.4 pelos SHAs completos verificados; alinha o deploy, README e as duas cópias do inventário ao Wrangler 4.128.0 já fixado. Os textos MIT e Apache-2.0 das duas tags oficiais são idênticos; o snapshot histórico dos bundles foi preservado.

Validação local: 348 testes em 59 arquivos, lint, Biome, formatação e ambos os builds dos pacotes raiz/frontend aprovados, além de Actionlint e Zizmor. A primeira execução teve um timeout de 5000 ms em um teste; a repetição integral, sem alteração do código ou dos limites, passou. As duas reproduções de divergência passaram para zero. Manifestos e lockfiles preservados; Node local 26, CI nativa 24.

Acompanhamento: [LCV-178](https://linear.app/lcv-ideas-software/issue/LCV-178).
