### PR TITLE
Align current dependency inventory and Wrangler deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,5 +60,5 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
           workingDirectory: astrologo-frontend
-          wranglerVersion: "4.128.0"
+          wranglerVersion: "4.129.0"
           command: pages deploy dist --project-name=astrologo-frontend --branch=main --commit-dirty=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Corrigido
 
-- Sincronizadas as duas cópias do inventário de dependências diretas com os manifestos e lockfiles: `globals` 17.12.0 nos dois pacotes, `lucide-react` 1.39.0 e `@types/node` 26.4.1 no frontend. Os textos integrais das licenças permanecem inalterados.
+- Sincronizadas as duas cópias do inventário de dependências diretas com os manifestos e lockfiles: `globals` 17.12.0 e `eslint-plugin-react-refresh` 0.5.6 nos dois pacotes; `lucide-react` 1.40.0, `@biomejs/biome` 2.5.12, `@types/react-dom` 19.2.7, `vitest` 5.0.0 e `@types/node` 26.4.1 no frontend. Os textos integrais das licenças permanecem inalterados.
 
 - Os dois arquivos de configuração ESLint definem `parserOptions.tsconfigRootDir` como `import.meta.dirname`, conforme a opção oficial do typescript-eslint. Isso elimina a ambiguidade entre raiz e frontend quando a CI executa o lint antes de instalar o segundo pacote npm, sem ignorar arquivos nem desativar regras (ASTROLO-18 / #373).
 
@@ -15,9 +15,9 @@
 
 ### Alterado
 
-- Atualizados os pins oficiais de CodeQL para 4.38.0 e zizmor-action para 0.6.4; o input do deploy usa o Wrangler 4.128.0 já fixado no lockfile.
+- Atualizados os pins oficiais de CodeQL para 4.38.0 e zizmor-action para 0.6.4; o input do deploy e sua documentação passam a acompanhar o Wrangler 4.129.0 já fixado no lockfile do frontend.
 
-- O inventário acompanha as quatro atualizações de ferramentas do frontend (#364). A entrada do Wrangler acompanha a versão 4.128.0 fixada no lockfile; os textos MIT e Apache-2.0 do tag oficial são idênticos aos já preservados.
+- O inventário acompanha as quatro atualizações de ferramentas do frontend (#364). A entrada do Wrangler nas duas cópias do inventário acompanha a versão 4.129.0 fixada no lockfile, sob MIT OR Apache-2.0 conforme o artefato oficial.
 - As cópias canônicas do inventário acompanham o `typescript-eslint` 8.69.0 do frontend, sem alterar as obrigações de licença (#370).
 - As cópias canônicas do inventário acompanham o `typescript-eslint` 8.69.0 do pacote raiz, sem alterar as obrigações de licença (#369).
 - O inventário preserva a atualização anterior do `lucide-react` (#365); o teste customizado de inventário é aposentado nesta reforma.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ CI runs on PRs to `main` and manual dispatches with Node.js 24. It installs both
 npm roots with `npm ci`, then checks root ESLint/public HTML formatting and
 frontend ESLint, Biome, tests, Vite build and Wrangler Pages Functions build.
 Deploy repeats these checks on a push to `main` and publishes the application
-with the official Cloudflare Wrangler Action and Wrangler 4.128.0. The existing
+with the official Cloudflare Wrangler Action and Wrangler 4.129.0. The existing
 D1 binding, Swiss WASM preparation and application behavior remain unchanged.
 
 GitHub Pages serves the separate `site/` artifact, with a PR build and deployment

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -12,7 +12,7 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | package.json | eslint | devDependencies | ^10.9.1 | 10.9.1 | MIT | https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz |
 | package.json | eslint-config-prettier | devDependencies | ^10.1.8 | 10.1.8 | MIT | https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz |
 | package.json | eslint-plugin-react-hooks | devDependencies | ^7.1.1 | 7.1.1 | MIT | https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz |
-| package.json | eslint-plugin-react-refresh | devDependencies | ^0.5.5 | 0.5.5 | MIT | https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.5.tgz |
+| package.json | eslint-plugin-react-refresh | devDependencies | ^0.5.6 | 0.5.6 | MIT | https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.6.tgz |
 | package.json | globals | devDependencies | ^17.12.0 | 17.12.0 | MIT | https://registry.npmjs.org/globals/-/globals-17.12.0.tgz |
 | package.json | prettier | devDependencies | ^3.9.6 | 3.9.6 | MIT | https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz |
 | package.json | typescript-eslint | devDependencies | ^8.69.0 | 8.69.0 | MIT | https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz |
@@ -21,34 +21,34 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | astrologo-frontend/package.json | astronomy-engine | dependencies | 2.1.19 | 2.1.19 | MIT | https://registry.npmjs.org/astronomy-engine/-/astronomy-engine-2.1.19.tgz |
 | astrologo-frontend/package.json | d3-geo | dependencies | 3.1.1 | 3.1.1 | ISC | https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz |
 | astrologo-frontend/package.json | dompurify | dependencies | ^3.4.14 | 3.4.14 | (MPL-2.0 OR Apache-2.0) | https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz |
-| astrologo-frontend/package.json | lucide-react | dependencies | ^1.39.0 | 1.39.0 | ISC | https://registry.npmjs.org/lucide-react/-/lucide-react-1.39.0.tgz |
+| astrologo-frontend/package.json | lucide-react | dependencies | ^1.40.0 | 1.40.0 | ISC | https://registry.npmjs.org/lucide-react/-/lucide-react-1.40.0.tgz |
 | astrologo-frontend/package.json | react | dependencies | ^19.2.8 | 19.2.8 | MIT | https://registry.npmjs.org/react/-/react-19.2.8.tgz |
 | astrologo-frontend/package.json | react-dom | dependencies | ^19.2.8 | 19.2.8 | MIT | https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz |
 | astrologo-frontend/package.json | sanitize-html | dependencies | ^2.17.7 | 2.17.7 | MIT | https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz |
 | astrologo-frontend/package.json | tailwindcss | dependencies | ^4.3.3 | 4.3.3 | MIT | https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz |
 | astrologo-frontend/package.json | topojson-client | dependencies | 3.1.0 | 3.1.0 | ISC | https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz |
 | astrologo-frontend/package.json | world-atlas | dependencies | 2.0.2 | 2.0.2 | ISC | https://registry.npmjs.org/world-atlas/-/world-atlas-2.0.2.tgz |
-| astrologo-frontend/package.json | @biomejs/biome | devDependencies | ^2.5.11 | 2.5.11 | MIT OR Apache-2.0 | https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.11.tgz |
+| astrologo-frontend/package.json | @biomejs/biome | devDependencies | ^2.5.12 | 2.5.12 | MIT OR Apache-2.0 | https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.12.tgz |
 | astrologo-frontend/package.json | @eslint/js | devDependencies | ^10.0.1 | 10.0.1 | MIT | https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz |
 | astrologo-frontend/package.json | @fusionstrings/swiss-eph | devDependencies | 0.1.1 | 0.1.1 | AGPL-3.0 | https://registry.npmjs.org/@fusionstrings/swiss-eph/-/swiss-eph-0.1.1.tgz |
 | astrologo-frontend/package.json | @types/d3-geo | devDependencies | 3.1.1 | 3.1.1 | MIT | https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz |
 | astrologo-frontend/package.json | @types/node | devDependencies | ^26.4.1 | 26.4.1 | MIT | https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz |
 | astrologo-frontend/package.json | @types/react | devDependencies | ^19.2.18 | 19.2.18 | MIT | https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz |
-| astrologo-frontend/package.json | @types/react-dom | devDependencies | ^19.2.5 | 19.2.5 | MIT | https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz |
+| astrologo-frontend/package.json | @types/react-dom | devDependencies | ^19.2.7 | 19.2.7 | MIT | https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.7.tgz |
 | astrologo-frontend/package.json | @types/sanitize-html | devDependencies | ^2.16.1 | 2.16.1 | MIT | https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz |
 | astrologo-frontend/package.json | @types/topojson-client | devDependencies | 3.1.5 | 3.1.5 | MIT | https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.5.tgz |
 | astrologo-frontend/package.json | @vitejs/plugin-react | devDependencies | ^6.1.1 | 6.1.1 | MIT | https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.1.tgz |
 | astrologo-frontend/package.json | eslint | devDependencies | ^10.9.1 | 10.9.1 | MIT | https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz |
 | astrologo-frontend/package.json | eslint-config-prettier | devDependencies | ^10.1.8 | 10.1.8 | MIT | https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz |
 | astrologo-frontend/package.json | eslint-plugin-react-hooks | devDependencies | ^7.1.1 | 7.1.1 | MIT | https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz |
-| astrologo-frontend/package.json | eslint-plugin-react-refresh | devDependencies | ^0.5.5 | 0.5.5 | MIT | https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.5.tgz |
+| astrologo-frontend/package.json | eslint-plugin-react-refresh | devDependencies | ^0.5.6 | 0.5.6 | MIT | https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.6.tgz |
 | astrologo-frontend/package.json | fast-check | devDependencies | 4.9.0 | 4.9.0 | MIT | https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz |
 | astrologo-frontend/package.json | globals | devDependencies | ^17.12.0 | 17.12.0 | MIT | https://registry.npmjs.org/globals/-/globals-17.12.0.tgz |
 | astrologo-frontend/package.json | typescript | devDependencies | ~6.0.3 | 6.0.3 | Apache-2.0 | https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz |
 | astrologo-frontend/package.json | typescript-eslint | devDependencies | ^8.69.0 | 8.69.0 | MIT | https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz |
 | astrologo-frontend/package.json | vite | devDependencies | ^8.2.2 | 8.2.2 | MIT | https://registry.npmjs.org/vite/-/vite-8.2.2.tgz |
-| astrologo-frontend/package.json | vitest | devDependencies | ^4.1.11 | 4.1.11 | MIT | https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz |
-| astrologo-frontend/package.json | wrangler | devDependencies | 4.128.0 | 4.128.0 | MIT OR Apache-2.0 | https://registry.npmjs.org/wrangler/-/wrangler-4.128.0.tgz |
+| astrologo-frontend/package.json | vitest | devDependencies | ^5.0.0 | 5.0.0 | MIT | https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz |
+| astrologo-frontend/package.json | wrangler | devDependencies | 4.129.0 | 4.129.0 | MIT OR Apache-2.0 | https://registry.npmjs.org/wrangler/-/wrangler-4.129.0.tgz |
 
 ## Textos das licenças dos bundles publicados
 

--- a/astrologo-frontend/public/legal/THIRDPARTY.md
+++ b/astrologo-frontend/public/legal/THIRDPARTY.md
@@ -12,7 +12,7 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | package.json | eslint | devDependencies | ^10.9.1 | 10.9.1 | MIT | https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz |
 | package.json | eslint-config-prettier | devDependencies | ^10.1.8 | 10.1.8 | MIT | https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz |
 | package.json | eslint-plugin-react-hooks | devDependencies | ^7.1.1 | 7.1.1 | MIT | https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz |
-| package.json | eslint-plugin-react-refresh | devDependencies | ^0.5.5 | 0.5.5 | MIT | https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.5.tgz |
+| package.json | eslint-plugin-react-refresh | devDependencies | ^0.5.6 | 0.5.6 | MIT | https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.6.tgz |
 | package.json | globals | devDependencies | ^17.12.0 | 17.12.0 | MIT | https://registry.npmjs.org/globals/-/globals-17.12.0.tgz |
 | package.json | prettier | devDependencies | ^3.9.6 | 3.9.6 | MIT | https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz |
 | package.json | typescript-eslint | devDependencies | ^8.69.0 | 8.69.0 | MIT | https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz |
@@ -21,34 +21,34 @@ A tabela registra as dependências diretas dos manifestos npm e dos respectivos 
 | astrologo-frontend/package.json | astronomy-engine | dependencies | 2.1.19 | 2.1.19 | MIT | https://registry.npmjs.org/astronomy-engine/-/astronomy-engine-2.1.19.tgz |
 | astrologo-frontend/package.json | d3-geo | dependencies | 3.1.1 | 3.1.1 | ISC | https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz |
 | astrologo-frontend/package.json | dompurify | dependencies | ^3.4.14 | 3.4.14 | (MPL-2.0 OR Apache-2.0) | https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz |
-| astrologo-frontend/package.json | lucide-react | dependencies | ^1.39.0 | 1.39.0 | ISC | https://registry.npmjs.org/lucide-react/-/lucide-react-1.39.0.tgz |
+| astrologo-frontend/package.json | lucide-react | dependencies | ^1.40.0 | 1.40.0 | ISC | https://registry.npmjs.org/lucide-react/-/lucide-react-1.40.0.tgz |
 | astrologo-frontend/package.json | react | dependencies | ^19.2.8 | 19.2.8 | MIT | https://registry.npmjs.org/react/-/react-19.2.8.tgz |
 | astrologo-frontend/package.json | react-dom | dependencies | ^19.2.8 | 19.2.8 | MIT | https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz |
 | astrologo-frontend/package.json | sanitize-html | dependencies | ^2.17.7 | 2.17.7 | MIT | https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz |
 | astrologo-frontend/package.json | tailwindcss | dependencies | ^4.3.3 | 4.3.3 | MIT | https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz |
 | astrologo-frontend/package.json | topojson-client | dependencies | 3.1.0 | 3.1.0 | ISC | https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz |
 | astrologo-frontend/package.json | world-atlas | dependencies | 2.0.2 | 2.0.2 | ISC | https://registry.npmjs.org/world-atlas/-/world-atlas-2.0.2.tgz |
-| astrologo-frontend/package.json | @biomejs/biome | devDependencies | ^2.5.11 | 2.5.11 | MIT OR Apache-2.0 | https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.11.tgz |
+| astrologo-frontend/package.json | @biomejs/biome | devDependencies | ^2.5.12 | 2.5.12 | MIT OR Apache-2.0 | https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.12.tgz |
 | astrologo-frontend/package.json | @eslint/js | devDependencies | ^10.0.1 | 10.0.1 | MIT | https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz |
 | astrologo-frontend/package.json | @fusionstrings/swiss-eph | devDependencies | 0.1.1 | 0.1.1 | AGPL-3.0 | https://registry.npmjs.org/@fusionstrings/swiss-eph/-/swiss-eph-0.1.1.tgz |
 | astrologo-frontend/package.json | @types/d3-geo | devDependencies | 3.1.1 | 3.1.1 | MIT | https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz |
 | astrologo-frontend/package.json | @types/node | devDependencies | ^26.4.1 | 26.4.1 | MIT | https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz |
 | astrologo-frontend/package.json | @types/react | devDependencies | ^19.2.18 | 19.2.18 | MIT | https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz |
-| astrologo-frontend/package.json | @types/react-dom | devDependencies | ^19.2.5 | 19.2.5 | MIT | https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz |
+| astrologo-frontend/package.json | @types/react-dom | devDependencies | ^19.2.7 | 19.2.7 | MIT | https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.7.tgz |
 | astrologo-frontend/package.json | @types/sanitize-html | devDependencies | ^2.16.1 | 2.16.1 | MIT | https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz |
 | astrologo-frontend/package.json | @types/topojson-client | devDependencies | 3.1.5 | 3.1.5 | MIT | https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.5.tgz |
 | astrologo-frontend/package.json | @vitejs/plugin-react | devDependencies | ^6.1.1 | 6.1.1 | MIT | https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.1.tgz |
 | astrologo-frontend/package.json | eslint | devDependencies | ^10.9.1 | 10.9.1 | MIT | https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz |
 | astrologo-frontend/package.json | eslint-config-prettier | devDependencies | ^10.1.8 | 10.1.8 | MIT | https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz |
 | astrologo-frontend/package.json | eslint-plugin-react-hooks | devDependencies | ^7.1.1 | 7.1.1 | MIT | https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz |
-| astrologo-frontend/package.json | eslint-plugin-react-refresh | devDependencies | ^0.5.5 | 0.5.5 | MIT | https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.5.tgz |
+| astrologo-frontend/package.json | eslint-plugin-react-refresh | devDependencies | ^0.5.6 | 0.5.6 | MIT | https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.6.tgz |
 | astrologo-frontend/package.json | fast-check | devDependencies | 4.9.0 | 4.9.0 | MIT | https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz |
 | astrologo-frontend/package.json | globals | devDependencies | ^17.12.0 | 17.12.0 | MIT | https://registry.npmjs.org/globals/-/globals-17.12.0.tgz |
 | astrologo-frontend/package.json | typescript | devDependencies | ~6.0.3 | 6.0.3 | Apache-2.0 | https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz |
 | astrologo-frontend/package.json | typescript-eslint | devDependencies | ^8.69.0 | 8.69.0 | MIT | https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz |
 | astrologo-frontend/package.json | vite | devDependencies | ^8.2.2 | 8.2.2 | MIT | https://registry.npmjs.org/vite/-/vite-8.2.2.tgz |
-| astrologo-frontend/package.json | vitest | devDependencies | ^4.1.11 | 4.1.11 | MIT | https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz |
-| astrologo-frontend/package.json | wrangler | devDependencies | 4.128.0 | 4.128.0 | MIT OR Apache-2.0 | https://registry.npmjs.org/wrangler/-/wrangler-4.128.0.tgz |
+| astrologo-frontend/package.json | vitest | devDependencies | ^5.0.0 | 5.0.0 | MIT | https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz |
+| astrologo-frontend/package.json | wrangler | devDependencies | 4.129.0 | 4.129.0 | MIT OR Apache-2.0 | https://registry.npmjs.org/wrangler/-/wrangler-4.129.0.tgz |
 
 ## Textos das licenças dos bundles publicados
 


### PR DESCRIPTION
O deploy selecionava Wrangler 4.128.0 enquanto o frontend já fixa 4.129.0. As duas cópias do inventário também registravam versões anteriores de sete relações diretas. O input, README, Unreleased e inventários passam a refletir os manifestos e lockfiles atuais.

As 41 relações de cada inventário foram comparadas com as declarações, versões resolvidas, licenças e URLs dos lockfiles; as cópias públicas são idênticas. A reprodução falha antes e passa depois. Os sete gates obrigatórios passaram em PowerShell: lint raiz/frontend, formatação HTML pública, Biome, testes, build e build das Functions com Wrangler 4.129.0.

Manifestos, lockfiles, código, NOTICE e o snapshot histórico das Functions permanecem preservados. ASTROLO-4 continua com seu bloqueio externo próprio.

Closes #384

Linear: [ASTROLO-21](https://linear.app/lcv-ideas-software/issue/ASTROLO-21/alinhar-inventario-direto-e-deploy-as-versoes-atuais-dos-lockfiles)
Auditoria: [LCV-181](https://linear.app/lcv-ideas-software/issue/LCV-181)
